### PR TITLE
Fix Django "consume iterator" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
-- Nothing (yet)!
+- Prevent responses with no body from creating a warning by providing Django an empty async iterable as the file content.
+- Force Django>=3.2 to use async file responses if possible, regardless of whether the middleware is run in sync or async mode.
 
 ## [1.0.0] - 2024-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ Using the following categories, list your changes in this order:
 
 ## [Unreleased]
 
-- Prevent responses with no body from creating a warning by providing Django an empty async iterable as the file content.
-- Force Django>=3.2 to use async file responses if possible, regardless of whether the middleware is run in sync or async mode.
+### Fixed
+
+- Fix Django "StreamingHttpResponse must consume synchronous iterators" warning
 
 ## [1.0.0] - 2024-05-08
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
   - Reference:
       - ServeStaticASGI: servestatic-asgi.md
       - ServeStatic: servestatic.md
-      - Django Project:
+      - Django:
           - Settings: django-settings.md
           - FAQ: django-faq.md
   - About:

--- a/src/servestatic/middleware.py
+++ b/src/servestatic/middleware.py
@@ -162,7 +162,7 @@ class ServeStaticMiddleware(ServeStatic):
         if iscoroutinefunction(self.get_response):
             return self.acall(request)
 
-        # Force Django >= 3.2 use async file responses when using ASGI, even
+        # Allow Django >= 3.2 to use async file responses when running via ASGI, even
         # if Django forces this middleware to run synchronously
         if django.VERSION >= (3, 2):
             return asyncio.run(self.acall(request))
@@ -171,8 +171,8 @@ class ServeStaticMiddleware(ServeStatic):
         return self.call(request)
 
     def call(self, request):
-        """If the URL contains a static file, serve it.
-        Otherwise, continue to the next middleware."""
+        """If the URL contains a static file, serve it. Otherwise, continue to the next
+        middleware."""
         if self.autorefresh:
             static_file = self.find_file(request.path_info)
         else:
@@ -184,8 +184,8 @@ class ServeStaticMiddleware(ServeStatic):
         return self.get_response(request)
 
     async def acall(self, request):
-        """If the URL contains a static file, serve it.
-        Otherwise, continue to the next middleware."""
+        """If the URL contains a static file, serve it. Otherwise, continue to the next
+        middleware."""
         if self.autorefresh and hasattr(asyncio, "to_thread"):
             # Use a thread while searching disk for files on Python 3.9+
             static_file = await asyncio.to_thread(self.find_file, request.path_info)


### PR DESCRIPTION
## Description

There are some circumstances where Django >4.2 would show the following warning: `Warning: StreamingHttpResponse must consume synchronous iterators in order to serve them asynchronously. Use an asynchronous iterator instead.`

There are two culprits are that caused these warnings:
- "304 file unchanged" file responses were being sent to Django with an empty tuple as the file content, which is technically not asynchronous. 
- Django's sync/async middleware auto selection prefers middleware to run in sync mode, even when it didn't make sense. This prevented ServeStatic from generating async file responses.

## Changelog

- Prevent responses with no body from creating a warning by providing Django a "placeholder" empty async iterable as the file content.
- Force Django>=3.2 to try using async file responses, even if the middleware is not running in async mode.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
