### PR TITLE
Bump publishing workflow version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,4 +260,4 @@ jobs:
           name: artifacts
           path: dist
       - name: Publish build to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.10.1
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

Seems like the publishing CI is broken for unknown reasons. Perhaps bumping the publishing workflow version may help.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
