### PR TITLE
Make the ASGI middleware compatible with lifespan protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
--   Nothing (yet)!
+### Fixed
+
+-   Fixed a bug where `ServeStaticASGI` was preventing compatibility with the `lifespan` protocol. All non-HTTP requests are now properly forwarded to the user's ASGI app.
 
 ## [3.0.1] - 2025-03-02
 

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -19,7 +19,6 @@ class ServeStaticASGI(ServeStaticBase):
         if scope["type"] == "http":
             # Determine if the request is for a static file
             path = decode_path_info(scope["path"])
-
             if self.autorefresh:
                 static_file = await asyncio.to_thread(self.find_file, path)
             else:

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -16,19 +16,19 @@ class ServeStaticASGI(ServeStaticBase):
         if not self.user_app:
             self.user_app = guarantee_single_callable(self.application)
 
-        # Determine if the request is for a static file
-        path = decode_path_info(scope["path"])
-        static_file = None
         if scope["type"] == "http":
+            # Determine if the request is for a static file
+            path = decode_path_info(scope["path"])
+
             if self.autorefresh:
                 static_file = await asyncio.to_thread(self.find_file, path)
             else:
                 static_file = self.files.get(path)
 
-        # Serve static file if it exists
-        if static_file:
-            await FileServerASGI(static_file)(scope, receive, send)
-            return
+            # Serve static file if it exists
+            if static_file:
+                await FileServerASGI(static_file)(scope, receive, send)
+                return
 
         # Serve the user's ASGI application
         await self.user_app(scope, receive, send)

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -8,7 +8,7 @@ import pytest
 from servestatic import utils as servestatic_utils
 from servestatic.asgi import ServeStaticASGI
 
-from .utils import AsgiReceiveEmulator, AsgiBaseScopeEmulator, AsgiScopeEmulator, AsgiSendEmulator, Files
+from .utils import AsgiHttpScopeEmulator, AsgiReceiveEmulator, AsgiScopeEmulator, AsgiSendEmulator, Files
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def application(request, test_files):
 
 
 def test_get_js_static_file(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js"})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -55,7 +55,7 @@ def test_get_js_static_file(application, test_files):
 
 
 def test_redirect_preserves_query_string(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/with-index", "query_string": b"v=1&x=2"})
+    scope = AsgiHttpScopeEmulator({"path": "/static/with-index", "query_string": b"v=1&x=2"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -63,7 +63,7 @@ def test_redirect_preserves_query_string(application, test_files):
 
 
 def test_user_app(application):
-    scope = AsgiScopeEmulator({"path": "/"})
+    scope = AsgiHttpScopeEmulator({"path": "/"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -73,7 +73,7 @@ def test_user_app(application):
 
 
 def test_ws_scope(application):
-    scope = AsgiScopeEmulator({"type": "websocket"})
+    scope = AsgiHttpScopeEmulator({"type": "websocket"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     with pytest.raises(RuntimeError):
@@ -81,7 +81,7 @@ def test_ws_scope(application):
 
 
 def test_lifespan_scope(application):
-    scope = AsgiBaseScopeEmulator({"type": "lifespan"})
+    scope = AsgiScopeEmulator({"type": "lifespan"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     with pytest.raises(RuntimeError):
@@ -89,7 +89,7 @@ def test_lifespan_scope(application):
 
 
 def test_head_request(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js", "method": "HEAD"})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "method": "HEAD"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -100,7 +100,7 @@ def test_head_request(application, test_files):
 
 
 def test_small_block_size(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js"})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
 
@@ -112,7 +112,7 @@ def test_small_block_size(application, test_files):
 
 
 def test_request_range_response(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js", "headers": [(b"range", b"bytes=0-13")]})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "headers": [(b"range", b"bytes=0-13")]})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -120,7 +120,7 @@ def test_request_range_response(application, test_files):
 
 
 def test_out_of_range_error(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js", "headers": [(b"range", b"bytes=10000-11000")]})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "headers": [(b"range", b"bytes=10000-11000")]})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -129,7 +129,7 @@ def test_out_of_range_error(application, test_files):
 
 
 def test_wrong_method_type(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/app.js", "method": "PUT"})
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "method": "PUT"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))
@@ -137,7 +137,7 @@ def test_wrong_method_type(application, test_files):
 
 
 def test_large_static_file(application, test_files):
-    scope = AsgiScopeEmulator({"path": "/static/large-file.txt", "headers": []})
+    scope = AsgiHttpScopeEmulator({"path": "/static/large-file.txt", "headers": []})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(application(scope, receive, send))

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -8,7 +8,7 @@ import pytest
 from servestatic import utils as servestatic_utils
 from servestatic.asgi import ServeStaticASGI
 
-from .utils import AsgiReceiveEmulator, AsgiScopeEmulator, AsgiSendEmulator, Files
+from .utils import AsgiReceiveEmulator, AsgiBaseScopeEmulator, AsgiScopeEmulator, AsgiSendEmulator, Files
 
 
 @pytest.fixture
@@ -74,6 +74,14 @@ def test_user_app(application):
 
 def test_ws_scope(application):
     scope = AsgiScopeEmulator({"type": "websocket"})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    with pytest.raises(RuntimeError):
+        asyncio.run(application(scope, receive, send))
+
+
+def test_lifespan_scope(application):
+    scope = AsgiBaseScopeEmulator({"type": "lifespan"})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     with pytest.raises(RuntimeError):

--- a/tests/test_django_servestatic.py
+++ b/tests/test_django_servestatic.py
@@ -27,8 +27,8 @@ from servestatic.utils import AsyncFile
 from .utils import (
     AppServer,
     AsgiAppServer,
+    AsgiHttpScopeEmulator,
     AsgiReceiveEmulator,
-    AsgiScopeEmulator,
     AsgiSendEmulator,
     Files,
 )
@@ -112,7 +112,7 @@ def test_versioned_file_cached_forever(server, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_versioned_file_cached_forever_brotli(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"accept-encoding", b"br")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"accept-encoding", b"br")]})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(AsgiAppServer(asgi_application)(scope, receive, send))
@@ -129,7 +129,7 @@ def test_asgi_versioned_file_cached_forever_brotli(asgi_application, static_file
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_versioned_file_cached_forever_brotli_2(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"accept-encoding", b"br")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"accept-encoding", b"br")]})
 
     async def executor():
         communicator = ApplicationCommunicator(asgi_application, scope)
@@ -358,7 +358,7 @@ def test_range_response(server, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_range_response(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"range", b"bytes=0-13")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"range", b"bytes=0-13")]})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(AsgiAppServer(asgi_application)(scope, receive, send))
@@ -372,7 +372,7 @@ def test_asgi_range_response(asgi_application, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_range_response_2(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"range", b"bytes=0-13")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"range", b"bytes=0-13")]})
 
     async def executor():
         communicator = ApplicationCommunicator(asgi_application, scope)
@@ -401,7 +401,7 @@ def test_out_of_range_error(server, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_out_of_range_error(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"range", b"bytes=900-999")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"range", b"bytes=900-999")]})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(AsgiAppServer(asgi_application)(scope, receive, send))
@@ -412,7 +412,7 @@ def test_asgi_out_of_range_error(asgi_application, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_asgi_out_of_range_error_2(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": [(b"range", b"bytes=900-999")]})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": [(b"range", b"bytes=900-999")]})
 
     async def executor():
         communicator = ApplicationCommunicator(asgi_application, scope)
@@ -430,7 +430,7 @@ def test_asgi_out_of_range_error_2(asgi_application, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_large_static_file(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.txt_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": []})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": []})
     receive = AsgiReceiveEmulator()
     send = AsgiSendEmulator()
     asyncio.run(AsgiAppServer(asgi_application)(scope, receive, send))
@@ -446,7 +446,7 @@ def test_large_static_file(asgi_application, static_files):
 @pytest.mark.usefixtures("_collect_static")
 def test_large_static_file_2(asgi_application, static_files):
     url = storage.staticfiles_storage.url(static_files.txt_path)
-    scope = AsgiScopeEmulator({"path": url, "headers": []})
+    scope = AsgiHttpScopeEmulator({"path": url, "headers": []})
 
     async def executor():
         communicator = ApplicationCommunicator(asgi_application, scope)
@@ -483,14 +483,14 @@ def test_manifest_with_keep_only_hashed(static_files):
             assert not hashed_path.endswith("app.js")
 
             # Check if SERVESTATIC_KEEP_ONLY_HASHED_FILES removed the original file
-            scope = AsgiScopeEmulator({"path": original_path, "headers": []})
+            scope = AsgiHttpScopeEmulator({"path": original_path, "headers": []})
             receive = AsgiReceiveEmulator()
             send = AsgiSendEmulator()
             asyncio.run(AsgiAppServer(get_asgi_application())(scope, receive, send))
             assert send.status == 404
 
             # Check if the hashed file can be served
-            scope = AsgiScopeEmulator({"path": hashed_path, "headers": []})
+            scope = AsgiHttpScopeEmulator({"path": hashed_path, "headers": []})
             receive = AsgiReceiveEmulator()
             send = AsgiSendEmulator()
             asyncio.run(AsgiAppServer(get_asgi_application())(scope, receive, send))
@@ -517,7 +517,7 @@ def test_manifest_with_keep_only_hashed_2():
 
             # Check if SERVESTATIC_KEEP_ONLY_HASHED_FILES removed the original file
             async def executor():
-                scope = AsgiScopeEmulator({"path": original_path, "headers": []})
+                scope = AsgiHttpScopeEmulator({"path": original_path, "headers": []})
                 communicator = ApplicationCommunicator(get_asgi_application(), scope)
                 await communicator.send_input(scope)
                 response_start = await communicator.receive_output()
@@ -529,7 +529,7 @@ def test_manifest_with_keep_only_hashed_2():
 
             # Check if the hashed file can be served
             async def executor_2():
-                scope = AsgiScopeEmulator({"path": hashed_path, "headers": []})
+                scope = AsgiHttpScopeEmulator({"path": hashed_path, "headers": []})
                 communicator = ApplicationCommunicator(get_asgi_application(), scope)
                 await communicator.send_input(scope)
                 response_start = await communicator.receive_output()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,7 +72,7 @@ class Files:
             setattr(self, f"{name}_content", content)
 
 
-class AsgiBaseScopeEmulator(dict):
+class AsgiScopeEmulator(dict):
     """
     Simulate a basic ASGI scope with minimal default values.
     Individual scope values can be overridden by passing a dictionary to the constructor.
@@ -89,7 +89,7 @@ class AsgiBaseScopeEmulator(dict):
         super().__init__(scope)
 
 
-class AsgiScopeEmulator(AsgiBaseScopeEmulator):
+class AsgiHttpScopeEmulator(AsgiScopeEmulator):
     """
     Simulate a detailed ASGI scope (like HTTP/WS).
     Individual scope values can be overridden by passing a dictionary to the constructor.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,13 +72,31 @@ class Files:
             setattr(self, f"{name}_content", content)
 
 
-class AsgiScopeEmulator(dict):
-    """Simulate a real scope. Individual scope values can be overridden by passing
-    a dictionary to the constructor."""
+class AsgiBaseScopeEmulator(dict):
+    """
+    Simulate a basic ASGI scope with minimal default values.
+    Individual scope values can be overridden by passing a dictionary to the constructor.
+    """
 
     def __init__(self, scope_overrides: dict | None = None):
         scope = {
             "asgi": {"version": "3.0"},
+        }
+
+        if scope_overrides:  # pragma: no cover
+            scope.update(scope_overrides)
+
+        super().__init__(scope)
+
+
+class AsgiScopeEmulator(AsgiBaseScopeEmulator):
+    """
+    Simulate a detailed ASGI scope (like HTTP/WS).
+    Individual scope values can be overridden by passing a dictionary to the constructor.
+    """
+
+    def __init__(self, scope_overrides: dict | None = None):
+        scope = {
             "client": ["127.0.0.1", 64521],
             "headers": [
                 (b"host", b"127.0.0.1:8000"),


### PR DESCRIPTION
Make ASGI middleware properly forward lifespan scope event to an upstream instead of failing.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
