### PR TITLE
4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Don't forget to remove deprecated code on each major release!
 - Added support for `zstd` compression on Python 3.14+.
 - Added support for the top-level `servestatic` module to run as a Django app.
 - Added Django system checks to test for common misconfigurations.
-- Added a new `allow_unsafe_symlinks` configuration option for WSGI/ASGI
-- Added a new `SERVESTATIC_ALLOW_UNSAFE_SYMLINKS` configuration option for Django.
+- Added `allow_unsafe_symlinks` configuration option for WSGI/ASGI
+- Added `SERVESTATIC_ALLOW_UNSAFE_SYMLINKS` configuration option for Django.
 - Added `jxl` image support.
 
 ### Changed
@@ -35,7 +35,6 @@ Don't forget to remove deprecated code on each major release!
 - Improved event-loop handling for ASGI file iterator.
 - Installing `servestatic` as a Django app is now the suggested configuration. A warning will appear if it is not detected in `INSTALLED_APPS` when `DEBUG` is `True`.
 - `servestatic.runserver_nostatic` is no longer the recommended Django app installation path. This import path will be retained to ease `WhiteNoise` to `ServeStatic` migration, but now the documentation recommends to use the top-level `servestatic` module instead.
-- For security purposes, `ServeStatic` will no longer follow unsafe symlinks by default. If your symlinks point to files outside of your static root, it is highly recommended to copy them instead. This behavior can be disabled for trusted deployments using `allow_unsafe_symlinks` / `SERVESTATIC_ALLOW_UNSAFE_SYMLINKS`.
 
 ### Fixed
 
@@ -44,7 +43,7 @@ Don't forget to remove deprecated code on each major release!
 ### Security
 
 - Hardened `autorefresh` path matching to prevent potential path traversal or path clobbering.
-- Hardened static file resolution to block symlink breakout by default.
+- Hardened static file resolution to block symlink breakout by default. If your symlinks point to files outside of your static root, it is highly recommended to copy them instead.
 
 ## [4.0.0] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Don't forget to remove deprecated code on each major release!
 ### Added
 
 - Added new Django setting `SERVESTATIC_USE_STATIC_ROOT` to allow users to opt in to having `ServeStatic` scan all files within `STATIC_ROOT` at start-up. This is now enabled by default.
+- Add JavaScript and CSS minification support to the `servestatic` CLI command.
+- Add JavaScript and CSS minification support to the `servestatic` the Django storage backend.
+
 
 ## [4.1.0] - 2026-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Don't forget to remove deprecated code on each major release!
 
 - Nothing (yet)
 
+## [4.2.0] - 2026-04-01
+
+### Added
+
+- Added new Django setting `SERVESTATIC_USE_STATIC_ROOT` to allow users to opt in to having `ServeStatic` scan all files within `STATIC_ROOT` at start-up. This is now enabled by default.
+
 ## [4.1.0] - 2026-03-07
 
 !!! tip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,8 @@ Don't forget to remove deprecated code on each major release!
 
 - Forked from [`whitenoise`](https://github.com/evansd/whitenoise) to add ASGI support.
 
-[Unreleased]: https://github.com/Archmonger/ServeStatic/compare/4.1.0...HEAD
+[Unreleased]: https://github.com/Archmonger/ServeStatic/compare/4.2.0...HEAD
+[4.2.0]: https://github.com/Archmonger/ServeStatic/compare/4.1.0...4.2.0
 [4.1.0]: https://github.com/Archmonger/ServeStatic/compare/4.0.0...4.1.0
 [4.0.0]: https://github.com/Archmonger/ServeStatic/compare/3.1.0...4.0.0
 [3.1.0]: https://github.com/Archmonger/ServeStatic/compare/3.0.2...3.1.0

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 
 _Production-grade static file server for Python WSGI & ASGI._
 
-_This project is a fork of [WhiteNoise](https://github.com/evansd/whitenoise) for [ASGI support, bug fixes, security updates, new features, and performance upgrades](https://archmonger.github.io/ServeStatic/latest/changelog/)._
+_This project is a [fork](https://github.com/evansd/whitenoise/pull/359#issuecomment-2226889088) of [WhiteNoise](https://github.com/evansd/whitenoise) for [ASGI support, bug fixes, security updates, new features, and performance upgrades](https://archmonger.github.io/ServeStatic/latest/changelog/)._
 
 ---
 
-`ServeStatic` simplifies static file serving with minimal lines of configuration. It enables you to create a self-contained unit (WSGI, ASGI, Django, or 'standalone') without requiring external services like Nginx or Amazon S3. This can simplify any production deployment, but is especially useful for platforms like Heroku, OpenShift, and other PaaS providers.
+`ServeStatic` simplifies static file serving with minimal lines of configuration. It enables you to create a self-contained unit without requiring external services like Nginx or Amazon S3. This can simplify any production deployment, but is especially useful for platforms like Heroku, OpenShift, and other PaaS providers.
 
-It is designed to work seamlessly with CDNs to ensure high performance for traffic-intensive sites, and is compatible with any ASGI/WSGI app. A command-line interface is provided to perform common tasks such as compression, file-name hashing, and manifest generation. Extra features and auto-configuration are available for [Django](https://www.djangoproject.com/) users.
+It is designed to work seamlessly with CDNs to ensure high performance for traffic-intensive sites. It can be run in "standalone" mode, or alongside any pre-existing ASGI/WSGI app. A command-line interface is provided to perform common tasks such as multi-format compression, file-name hashing, and manifest generation. Extra features and auto-configuration are available for [Django](https://www.djangoproject.com/) users.
 
 When using `ServeStatic`, best practices are automatically handled such as:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _This project is a [fork](https://github.com/evansd/whitenoise/pull/359#issuecom
 
 `ServeStatic` simplifies static file serving with minimal lines of configuration. It enables you to create a self-contained unit without requiring external services like Nginx or Amazon S3. This can simplify any production deployment, but is especially useful for platforms like Heroku, OpenShift, and other PaaS providers.
 
-It is designed to work seamlessly with CDNs to ensure high performance for traffic-intensive sites. It can be run in "standalone" mode, or alongside any pre-existing ASGI/WSGI app. A command-line interface is provided to perform common tasks such as multi-format compression, file-name hashing, and manifest generation. Extra features and auto-configuration are available for [Django](https://www.djangoproject.com/) users.
+It is designed to work seamlessly with CDNs to ensure high performance for traffic-intensive sites. It can be run in "standalone" mode, or alongside any preexisting ASGI/WSGI app. A command-line interface is provided to perform common tasks such as multi-format compression, file-name hashing, and manifest generation. Extra features and auto-configuration are available for [Django](https://www.djangoproject.com/) users.
 
 When using `ServeStatic`, best practices are automatically handled such as:
 

--- a/docs/src/asgi.md
+++ b/docs/src/asgi.md
@@ -18,9 +18,7 @@ application.add_files("/path/to/more/static/files", prefix="more-files/")
 
 Alternatively, you can use ServeStatic as a standalone file server by not providing a WSGI app. For example:
 
-```python
-from servestatic import ServeStaticASGI
-
+```python linenums="0"
 application = ServeStaticASGI(None, root="/path/to/static/files")
 ```
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -32,15 +32,14 @@ options:
   --hash                Generate hashed versions of files. (default: False)
   --manifest            Generate a manifest file (staticfiles.json). (default:
                         False)
-  --merge-manifest      Merge the new manifest with an existing manifest in the
-                        dest directory. Fails if the existing manifest is not
-                        found. (default: False)
   --compress            Generate compressed versions (gzip/zstd/brotli) of
                         files.
                         (default: False)
   --clear               Empty the destination directory before processing.
                         (default: False)
-  -q, --quiet           Don't produce log output. (default: False)
+  --merge-manifest      Merge the new manifest with an existing manifest in the
+                        dest directory. Fails if the existing manifest is not
+                        found. (default: False)
   --copy-original       Copy the original unhashed files into the dest directory
                         alongside the hashed versions (only applies with
                         --hash). (default: False)
@@ -58,6 +57,7 @@ options:
   --zstd-level ZSTD_LEVEL
                         Compression level for zstd output (only applies with
                         --compress). (default: None)
+  -q, --quiet           Don't produce log output. (default: False)
   -e EXCLUDE, --exclude EXCLUDE
                         Glob pattern(s) to exclude from processing
                         (compression/hashing). These files are still copied.
@@ -76,7 +76,7 @@ You can also pass a custom zstd dictionary with `--zstd-dict` and optionally mar
 
 ## Hash Details
 
-This command will output a standard cache-busting static manifest configuration exactly mirroring Django's expected structures `ManifestStaticFilesStorage`.
+This command will output a cache-busting static manifest, which can be used to correlate the original file path to the hashed path.
 
 Every file provided in your directory gets duplicate versions bearing a unique MD5 hash signature of the internal stream state appended inside its extension structure (e.g., `test.css` -> `test.296ab49302a4.css`).
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,12 +1,12 @@
 # CLI Reference
 
-ServeStatic comes with a handy command line utility which can generate compressed versions of your static files and hash the file names (for cache busting, mimicking Django's `ManifestStaticFilesStorage`).
+ServeStatic comes with a handy command line utility for common static file operations: manifest generation, compression, minification, and hashing.
 
 You can either run this during development and commit your generated/compressed files to your repository, or you can run this as part of your build and deploy processes.
 
 !!! note
 
-    This CLI is intended for non-Django deployments. For Django users, compression and hashing is handled completely automatically within Django's `collectstatic` command if you're using ServeStatic's `CompressedManifestStaticFilesStorage` storage backend.
+    This CLI is intended for non-Django deployments. For Django users, these features are handled automatically within Django's `collectstatic` command when using ServeStatic's `CompressedManifestStaticFilesStorage` storage backend.
 
 ## Usage
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -12,11 +12,11 @@ You can either run this during development and commit your generated/compressed 
 
 ```console linenums="0"
 $ servestatic --help
-usage: servestatic [-h] [--all] [--hash] [--manifest] [--merge-manifest]
-                   [--compress] [--clear] [-q] [--copy-original] [--no-gzip]
-                   [--no-brotli] [--no-zstd] [--zstd-dict ZSTD_DICT]
-                   [--zstd-dict-raw] [--zstd-level ZSTD_LEVEL]
-                   [-e EXCLUDE]
+usage: servestatic [-h] [--all] [--hash] [--manifest] [--compress] [--clear]
+                   [--merge-manifest] [--copy-original] [--no-gzip]
+                   [--no-brotli] [--no-zstd] [--minify]
+                   [--zstd-dict ZSTD_DICT] [--zstd-dict-raw]
+                   [--zstd-level ZSTD_LEVEL] [-q] [-e EXCLUDE]
                    src dest
 
 Process static files: copy, optionally hash, and compress.
@@ -33,16 +33,16 @@ options:
   --manifest            Generate a manifest file (staticfiles.json). (default:
                         False)
   --compress            Generate compressed versions (gzip/zstd/brotli) of
-                        files.
-                        (default: False)
+                        files. (default: False)
+  --minify              Minify CSS and JS files. (default: False)
   --clear               Empty the destination directory before processing.
                         (default: False)
-  --merge-manifest      Merge the new manifest with an existing manifest in the
-                        dest directory. Fails if the existing manifest is not
-                        found. (default: False)
-  --copy-original       Copy the original unhashed files into the dest directory
-                        alongside the hashed versions (only applies with
-                        --hash). (default: False)
+  --merge-manifest      Merge the new manifest with an existing manifest in
+                        the dest directory. Fails if the existing manifest is
+                        not found. (default: False)
+  --copy-original       Copy the original unhashed files into the dest
+                        directory alongside the hashed versions (only applies
+                        with --hash). (default: False)
   --no-gzip             Don't produce gzip '.gz' files (only applies with
                         --compress). (default: True)
   --no-brotli           Don't produce brotli '.br' files (only applies with

--- a/docs/src/dictionary.txt
+++ b/docs/src/dictionary.txt
@@ -41,3 +41,5 @@ misconfigurations
 encodings
 symlink
 symlinks
+minification
+minify

--- a/docs/src/django-faq.md
+++ b/docs/src/django-faq.md
@@ -1,6 +1,6 @@
 ## How to I use `ServeStatic` with Django Compressor?
 
-For performance and security reasons `ServeStatic` does not check for new files after startup (unless using Django <span class="title-ref">DEBUG</span> mode). As such, all static files must be generated in advance. If you're using Django Compressor, this can be performed using its [offline compression](https://django-compressor.readthedocs.io/en/stable/usage.html#offline-compression) feature.
+For performance reasons `ServeStatic` does not check for new files after startup by default. As such, when using Django Compressor you must generate your compressed files by using the [offline compression](https://django-compressor.readthedocs.io/en/stable/usage.html#offline-compression) feature and then ensure that `SERVESTATIC_USE_STATIC_ROOT` is set to `True`.
 
 ---
 

--- a/docs/src/django-faq.md
+++ b/docs/src/django-faq.md
@@ -1,6 +1,8 @@
 ## How to I use `ServeStatic` with Django Compressor?
 
-For performance reasons `ServeStatic` does not check for new files after startup by default. As such, when using Django Compressor you must generate your compressed files by using the [offline compression](https://django-compressor.readthedocs.io/en/stable/usage.html#offline-compression) feature and then ensure that `SERVESTATIC_USE_STATIC_ROOT` is set to `True`.
+When using Django Compressor you must generate your compressed files by using the [offline compression](https://django-compressor.readthedocs.io/en/stable/usage.html#offline-compression) feature and then ensure that `SERVESTATIC_USE_STATIC_ROOT` is set to `True`.
+
+Alternatively, if you are only utilizing Django Compressor for its minification features and not its file concatenation features, you can set `SERVESTATIC_MINIFY` to `True` and remove your usage of Django Compressor entirely.
 
 ---
 

--- a/docs/src/django-faq.md
+++ b/docs/src/django-faq.md
@@ -56,6 +56,8 @@ If the problems persist then your issue is with Django itself (try the [docs](ht
 
 `ServeStatic` will only work with storage backends that stores their files on the local filesystem in `STATIC_ROOT`. It will not work with backends that store files remotely, for instance on Amazon S3.
 
+---
+
 ## Why does `ServeStatic` make my tests run slow?
 
 `ServeStatic` is designed to do as much work as possible upfront when the application starts so that it can serve files as efficiently as possible while the application is running. This makes sense for long-running production processes, but you might find that the added startup time is a problem during test runs when application instances are frequently being created and destroyed.
@@ -63,6 +65,8 @@ If the problems persist then your issue is with Django itself (try the [docs](ht
 The simplest way to fix this is to make sure that during testing the `SERVESTATIC_AUTOREFRESH` setting is set to `True`. (By default it is `True` when `DEBUG` is enabled and `False` otherwise.) This stops `ServeStatic` from scanning your static files on start up but other than that its behaviour should be exactly the same.
 
 It is also worth making sure you don't have unnecessary files in your `STATIC_ROOT` directory. In particular, be careful not to include a `node_modules` directory which can contain a very large number of files and significantly slow down your application startup. If you need to include specific files from `node_modules` then you can create symlinks from within your static directory to just the files you need.
+
+---
 
 ## Why do I get "ValueError: Missing staticfiles manifest entry for ..."?
 
@@ -75,6 +79,8 @@ python manage.py findstatic --verbosity 2 foo
 which will show you all the paths which Django searches for the file "foo".
 
 If, for some reason, you want Django to silently ignore such errors you can set `SERVESTATIC_MANIFEST_STRICT` to `False`.
+
+---
 
 ## How do I use `ServeStatic` with Webpack/Browserify/etc?
 
@@ -105,6 +111,8 @@ This means that Django can find the processed files, but doesn't need to know an
 The final `manage.py collectstatic` step writes "hash-versioned" and compressed copies of the static files into `static_root` ready for production.
 
 Note, both the `static_build` and `static_root` directories should be excluded from version control (e.g. through `.gitignore`) and only the `static_src` directory should be checked in.
+
+---
 
 ## How do I deploy an application which is not at the root of the domain?
 

--- a/docs/src/django-settings.md
+++ b/docs/src/django-settings.md
@@ -138,6 +138,33 @@ Because the compression process will only create compressed files where this res
 
 ---
 
+## `SERVESTATIC_MINIFY`
+
+**Default:** `False`
+
+If set to `True`, ServeStatic will minify CSS and JS files during the `post_process` step
+before compressing. This feature requires the optional `rcssmin` and `rjsmin` packages to be installed,
+which can be done via `pip install servestatic[minify]`. If enabled without the required
+packages, it will raise an `ImportError`.
+
+---
+
+## `SERVESTATIC_USE_GZIP`
+
+**Default:** `True`
+
+Enable or disable gzip output generation (`.gz`).
+
+---
+
+## `SERVESTATIC_USE_BROTLI`
+
+**Default:** `True`
+
+Enable or disable brotli output generation (`.br`) when `brotli` is available.
+
+---
+
 ## `SERVESTATIC_USE_ZSTD`
 
 **Default:** `True`

--- a/docs/src/django-settings.md
+++ b/docs/src/django-settings.md
@@ -30,7 +30,7 @@ Find and serve files using Django's manifest file.
 
 This is the most efficient way to determine what files are available, but it requires that you are using a [manifest-compatible](https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#manifeststaticfilesstorage) storage backend.
 
-When using ServeStatic's [`CompressedManifestStaticFilesStorage`](./django.md#step-2-add-compression-and-caching-support) storage backend, ServeStatic will no longer need to call `os.stat` on each file during startup.
+When using ServeStatic's [`CompressedManifestStaticFilesStorage`](./django.md#step-3-add-compression-and-caching-support) storage backend, ServeStatic will no longer need to call `os.stat` on each file during startup.
 
 ---
 
@@ -142,10 +142,7 @@ Because the compression process will only create compressed files where this res
 
 **Default:** `False`
 
-If set to `True`, ServeStatic will minify CSS and JS files during the `post_process` step
-before compressing. This feature requires the optional `rcssmin` and `rjsmin` packages to be installed,
-which can be done via `pip install servestatic[minify]`. If enabled without the required
-packages, it will raise an `ImportError`.
+If set to `True`, ServeStatic will minify CSS and JS files during the `post_process` step before compressing. This feature requires the optional `rcssmin` and `rjsmin` packages to be installed, which can be done via `pip install servestatic[minify]`. If enabled without the required packages, it will raise an `ImportError`.
 
 ---
 

--- a/docs/src/django-settings.md
+++ b/docs/src/django-settings.md
@@ -46,6 +46,16 @@ Note that `STATICFILES_DIRS` cannot equal `STATIC_ROOT` while running the `colle
 
 ---
 
+## `SERVESTATIC_USE_STATIC_ROOT`
+
+**Default:** `not (settings.py:SERVESTATIC_USE_MANIFEST or settings.py:SERVESTATIC_USE_FINDERS)`
+
+Find and serve all files within Django's `STATIC_ROOT` (file scan is only run during startup). This defaults to `True` if you do not have no other method configured.
+
+This allows users to have their `STATIC_ROOT` directory contain files which are created _after_ `manage.py collectstatic` is ran (e.g. by `django-compressor`).
+
+---
+
 ## `SERVESTATIC_MAX_AGE`
 
 **Default:** `60 if not settings.py:DEBUG else 0`

--- a/docs/src/django.md
+++ b/docs/src/django.md
@@ -4,7 +4,7 @@ This guide walks you through setting up a Django project with ServeStatic. In mo
 
 We mention Heroku in a few places, but there's nothing Heroku-specific about ServeStatic and the instructions below should apply whatever your hosting platform.
 
-## Step 1: Enable ServeStatic
+## Step 1: Install Middleware
 
 Edit your `settings.py` file and add ServeStatic to the `MIDDLEWARE` list.
 
@@ -20,22 +20,21 @@ MIDDLEWARE = [
 ]
 ```
 
-To enable ServeStatic's configuration checks, add `servestatic` to `INSTALLED_APPS`:
+## Step 2: Install Django App
+
+In development Django's `runserver` automatically takes over static file handling. In most cases this is fine, however this means that some of the improvements that ServeStatic makes to static file handling won't be available in development and it opens up the possibility for differences in behaviour between development and production environments. For this reason it's a good idea to use ServeStatic in development as well.
+
+You can disable Django's static file handling and allow ServeStatic to take over simply by passing the `--nostatic` option to the `runserver` command, but you need to remember to add this option every time you call `runserver`. An easier way is to add `servestatic` to the top of your `INSTALLED_APPS` list:
 
 ```python linenums="0"
 INSTALLED_APPS = [
     "servestatic",
+    "django.contrib.staticfiles",
     # ...
 ]
 ```
 
-That's it! ServeStatic is now configured to serve your static files. For optimal performance, proceed to the next step to enable compression and caching.
-
-??? question "How should I order my middleware?"
-
-    You might find other third-party middleware that suggests it should be given highest priority at the top of the middleware list. Unless you understand exactly what is happening you should always place `ServeStaticMiddleware` above all middleware other than `SecurityMiddleware`.
-
-## Step 2: Add compression and caching support
+## Step 3: Add compression and caching support
 
 ServeStatic comes with a storage backend which compresses your files and hashes them to unique names, so they can safely be cached forever. To use it, set it as your staticfiles storage backend in your settings file.
 
@@ -66,7 +65,7 @@ If you need to compress files outside of the static files storage system you can
 
     ServeStatic only sends compressed responses for encodings requested by the client, so enabling these formats remains backward-compatible.
 
-## Step 3: Make sure Django's `staticfiles` is configured correctly
+## Step 4: Make sure Django's `staticfiles` is configured correctly
 
 If you're familiar with Django you'll know what to do. If you're just getting started with a new Django project then you'll need add the following to the bottom of your `settings.py` file:
 
@@ -90,29 +89,13 @@ For further details see the Django [staticfiles](https://docs.djangoproject.com/
 
 ---
 
-## Step 4: Optional configuration
-
-### Modify ServeStatic's Django settings
+## Step 5: Optional configuration
 
 ServeStatic has a number of configuration options that you can set in your `settings.py` file.
 
 See the [reference documentation](./django-settings.md) for a full list of options.
 
-### Enable ServeStatic during development
-
-In development Django's `runserver` automatically takes over static file handling. In most cases this is fine, however this means that some of the improvements that ServeStatic makes to static file handling won't be available in development and it opens up the possibility for differences in behaviour between development and production environments. For this reason it's a good idea to use ServeStatic in development as well.
-
-You can disable Django's static file handling and allow ServeStatic to take over simply by passing the `--nostatic` option to the `runserver` command, but you need to remember to add this option every time you call `runserver`. An easier way is to add `servestatic` to the top of your `INSTALLED_APPS` list:
-
-```python linenums="0"
-INSTALLED_APPS = [
-    "servestatic",
-    "django.contrib.staticfiles",
-    # ...
-]
-```
-
-### Utilize a Content Delivery Network (CDN)
+## Step 6: Utilize a Content Delivery Network (CDN)
 
 <!--cdn-start-->
 

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -7,8 +7,8 @@ The documentation below is a quick-start guide to using ServeStatic to serve you
 Install with:
 
 ```bash linenums="0"
-# Note: 'brotli' is an optional extra that adds support for more efficient compression.
-pip install servestatic[brotli]
+# Note: 'brotli' and 'minify' are optional extras that add support for more efficient compression and minification.
+pip install servestatic[brotli, minify]
 ```
 
 ## Using with Django

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -7,7 +7,7 @@ The documentation below is a quick-start guide to using ServeStatic to serve you
 Install with:
 
 ```bash linenums="0"
-# Note: 'brotli' and 'minify' are optional extras that add support for more efficient compression and minification.
+# Note: 'brotli' and 'minify' are optional extras
 pip install servestatic[brotli, minify]
 ```
 

--- a/docs/src/wsgi.md
+++ b/docs/src/wsgi.md
@@ -14,9 +14,7 @@ application.add_files("/path/to/more/static/files", prefix="more-files/")
 
 Alternatively, you can use ServeStatic as a standalone file server by not providing a WSGI app. For example:
 
-```python
-from servestatic import ServeStatic
-
+```python linenums="0"
 application = ServeStatic(None, root="/path/to/static/files")
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = ["asgiref"]
 dynamic = ["version"]
 optional-dependencies.brotli = ["brotli"]
+optional-dependencies.minify = ["rcssmin", "rjsmin"]
 urls.Changelog = "https://archmonger.github.io/ServeStatic/latest/changelog/"
 urls.Documentation = "https://archmonger.github.io/ServeStatic/"
 urls.Source = "https://github.com/Archmonger/ServeStatic"
@@ -52,7 +53,15 @@ installer = "uv"
 # >>> Hatch Test Suite <<<
 
 [tool.hatch.envs.hatch-test]
-extra-dependencies = ["pytest-sugar", "httpx", "brotli", "pytest-timeout"]
+extra-dependencies = [
+  "pytest-sugar",
+  "httpx",
+  "brotli",
+  "pytest-timeout",
+  "brotli",
+  "rcssmin",
+  "rjsmin",
+]
 randomize = true
 matrix-name-format = "{variable}-{value}"
 timeout = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ matrix.django.dependencies = [
 template = "docs"
 detached = true
 dependencies = [
-  "mkdocs<2.0", # Mkdocs has some breaking changes planned that would brick mkdocs-material
+  "mkdocs<2.0",                                # Mkdocs has some breaking changes planned that would brick mkdocs-material
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocs-material",
   "mkdocs-include-markdown-plugin",
@@ -100,7 +100,7 @@ dependencies = [
   "mkdocs-git-authors-plugin",
   "mkdocs-minify-plugin",
   "mike",
-  "click==8.2.1", # Newer versions of click do not work with mkdocs<2.0
+  "click==8.2.1",                              # Newer versions of click do not work with mkdocs<2.0
 ]
 
 [tool.hatch.envs.docs.scripts]

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -1,0 +1,38 @@
+"""
+Development/debug script to parse pyproject.toml to find dependecies then install them in the local
+environment via `uv pip install -U <pkg_names>`
+"""
+
+import subprocess
+from pathlib import Path
+
+import tomllib as toml
+
+DEPENDENCIES = set()
+
+
+def find_deps(data):
+    """Recurse through all categories and find any list with `dependencies` in the name, then combine
+    all dependencies into a single list"""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if "dependencies" in key and isinstance(value, list) and value and isinstance(value[0], str):
+                DEPENDENCIES.update(value)
+            else:
+                find_deps(value)
+    elif isinstance(data, list):
+        for item in data:
+            find_deps(item)
+
+
+def install_deps():
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = toml.load(f)
+    find_deps(pyproject_data)
+    DEPENDENCIES.discard("ruff")  # ruff only exists in dev dependencies for CI purposes.
+    subprocess.run(["uv", "pip", "install", "-U", *DEPENDENCIES], check=False)  # noqa: S607
+
+
+if __name__ == "__main__":
+    install_deps()

--- a/scripts/security_probe.py
+++ b/scripts/security_probe.py
@@ -2,7 +2,14 @@
 This script performs a series of security probes against both the WSGI and ASGI versions of `ServeStatic` to check
 for vulnerabilities. The results are printed in a report format, indicating whether each probe passed or failed
 for both WSGI and ASGI implementations.
+
+This can be run via the command `hatch run "scripts/security_probe.py"` from the project root.
 """
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx", "tabulate"]
+# ///
 
 from __future__ import annotations
 
@@ -13,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
+from tabulate import tabulate
 
 from servestatic import ServeStatic, ServeStaticASGI
 
@@ -74,18 +82,15 @@ def prepare_fixture() -> tuple[Path, Path, str, bool]:
 def check_sync_probes(
     client: httpx.Client, outside_secret: str, symlink_created: bool
 ) -> dict[str, tuple[bool | None, str]]:
-    outcomes: dict[str, tuple[bool | None, str]] = {}
-
     response = client.get("/static/app.js")
     ok = response.status_code == 200 and outside_secret.encode() not in response.content
-    outcomes["baseline_static"] = (ok, f"status={response.status_code}")
-
+    outcomes: dict[str, tuple[bool | None, str]] = {"baseline_static": (ok, f"status={response.status_code}")}
     response = client.get("/static/%2e%2e/outside-secret.txt")
-    ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+    ok = response.status_code != 200 or outside_secret.encode() not in response.content
     outcomes["path_traversal_encoded_dotdot"] = (ok, f"status={response.status_code}")
 
     response = client.get("/static/..\\outside-secret.txt")
-    ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+    ok = response.status_code != 200 or outside_secret.encode() not in response.content
     outcomes["path_traversal_backslash"] = (ok, f"status={response.status_code}")
 
     response = client.get("/static/app.js.gz")
@@ -118,7 +123,7 @@ def check_sync_probes(
 
     if symlink_created:
         response = client.get("/static/link-outside.txt")
-        ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+        ok = response.status_code != 200 or outside_secret.encode() not in response.content
         outcomes["symlink_escape_from_static_root"] = (ok, f"status={response.status_code}")
     else:
         outcomes["symlink_escape_from_static_root"] = (None, "skipped (symlink unavailable)")
@@ -129,18 +134,15 @@ def check_sync_probes(
 async def check_async_probes(
     client: httpx.AsyncClient, outside_secret: str, symlink_created: bool
 ) -> dict[str, tuple[bool | None, str]]:
-    outcomes: dict[str, tuple[bool | None, str]] = {}
-
     response = await client.get("/static/app.js")
     ok = response.status_code == 200 and outside_secret.encode() not in response.content
-    outcomes["baseline_static"] = (ok, f"status={response.status_code}")
-
+    outcomes: dict[str, tuple[bool | None, str]] = {"baseline_static": (ok, f"status={response.status_code}")}
     response = await client.get("/static/%2e%2e/outside-secret.txt")
-    ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+    ok = response.status_code != 200 or outside_secret.encode() not in response.content
     outcomes["path_traversal_encoded_dotdot"] = (ok, f"status={response.status_code}")
 
     response = await client.get("/static/..\\outside-secret.txt")
-    ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+    ok = response.status_code != 200 or outside_secret.encode() not in response.content
     outcomes["path_traversal_backslash"] = (ok, f"status={response.status_code}")
 
     response = await client.get("/static/app.js.gz")
@@ -173,7 +175,7 @@ async def check_async_probes(
 
     if symlink_created:
         response = await client.get("/static/link-outside.txt")
-        ok = not (response.status_code == 200 and outside_secret.encode() in response.content)
+        ok = response.status_code != 200 or outside_secret.encode() not in response.content
         outcomes["symlink_escape_from_static_root"] = (ok, f"status={response.status_code}")
     else:
         outcomes["symlink_escape_from_static_root"] = (None, "skipped (symlink unavailable)")
@@ -188,28 +190,25 @@ def status_label(value: bool | None) -> str:
 
 
 def print_report(results: dict[str, ProbeOutcome]) -> None:
-    print("# ServeStatic Security Probe Report")
+    table_data = []
+    table_data.extend(
+        [
+            probe_name,
+            result.expected,
+            f"{status_label(result.wsgi_ok)} ({result.wsgi_detail})",
+            f"{status_label(result.asgi_ok)} ({result.asgi_detail})",
+        ]
+        for probe_name, result in results.items()
+    )
+    print(tabulate(table_data, headers=["Probe", "Expected", "WSGI", "ASGI"], tablefmt="github"))
     print()
-    print("| Probe | Expected | WSGI | ASGI |")
-    print("|---|---|---|---|")
-    for probe_name, result in results.items():
-        print(
-            f"| {probe_name} | {result.expected} | {status_label(result.wsgi_ok)} ({result.wsgi_detail}) | "
-            f"{status_label(result.asgi_ok)} ({result.asgi_detail}) |"
-        )
-
-    findings = []
-    for probe_name, result in results.items():
-        if result.wsgi_ok is False or result.asgi_ok is False:
-            findings.append(probe_name)
-
-    print()
+    findings = [name for name, result in results.items() if result.wsgi_ok is False or result.asgi_ok is False]
     if findings:
-        print("Potential Findings:")
-        for finding in findings:
-            print(f"- {finding}")
+        print("Summary: Issues detected in the following probes!\n")
+        for name in findings:
+            print(f"\t- {name}")
     else:
-        print("No exploitable issues detected by this probe set.")
+        print("Summary: No issues detected.")
 
 
 def run_probe() -> int:
@@ -270,5 +269,4 @@ def run_probe() -> int:
     return 1 if failures else 0
 
 
-if __name__ == "__main__":
-    raise SystemExit(run_probe())
+raise SystemExit(run_probe())

--- a/src/servestatic/__init__.py
+++ b/src/servestatic/__init__.py
@@ -3,6 +3,6 @@ from __future__ import annotations
 from servestatic.asgi import ServeStaticASGI
 from servestatic.wsgi import ServeStatic
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 __all__ = ["ServeStatic", "ServeStaticASGI"]

--- a/src/servestatic/apps.py
+++ b/src/servestatic/apps.py
@@ -11,6 +11,6 @@ from django.apps import AppConfig
 class ServeStaticConfig(AppConfig):
     name = "servestatic"
 
-    def ready(self):
+    def ready(self) -> None:
         super().ready()
         from servestatic import checks  # noqa: F401

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -1,33 +1,44 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from asgiref.compatibility import guarantee_single_callable
+from asgiref.typing import HTTPResponseBodyEvent, HTTPResponseStartEvent
 
 from servestatic.base import ServeStaticBase
 from servestatic.utils import decode_path_info, get_block_size
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPScope,
+        Scope,
+    )
+
+    from servestatic.responders import AsyncSlicedFile, Redirect, StaticFile
+    from servestatic.utils import AsyncFile
 
 
 class ServeStaticASGI(ServeStaticBase):
-    application: Callable
+    application: ASGI3Application
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         # Determine if the request is for a static file
         static_file = None
         if scope["type"] == "http":
-            path = decode_path_info(scope["path"])
+            http_scope = cast("HTTPScope", scope)
+            path = decode_path_info(http_scope["path"])
             if self.autorefresh:
                 static_file = await asyncio.to_thread(self.find_file, path)
             else:
                 static_file = self.files.get(path)
 
         # Serve static file if it exists
-        if static_file is not None:
-            return await FileServerASGI(static_file)(scope, receive, send)
+        if static_file:
+            return await FileServerASGI(static_file)(cast("HTTPScope", scope), receive, send)
 
         # Could not find a static file. Serve the default application instead.
         return await self.application(scope, receive, send)
@@ -45,11 +56,11 @@ class ServeStaticASGI(ServeStaticBase):
 class FileServerASGI:
     """Primitive ASGI v3 application that streams a StaticFile over HTTP in chunks."""
 
-    def __init__(self, static_file) -> None:
+    def __init__(self, static_file: StaticFile | Redirect) -> None:
         self.static_file = static_file
         self.block_size = get_block_size()
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: HTTPScope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         # Convert ASGI headers into WSGI headers. Allows us to reuse all of our WSGI
         # header logic inside of aget_response().
         wsgi_headers = {
@@ -62,31 +73,31 @@ class FileServerASGI:
         response = await self.static_file.aget_response(scope["method"], wsgi_headers)
 
         # Start a new HTTP response for the file
-        await send({
-            "type": "http.response.start",
-            "status": response.status,
-            "headers": [
-                # Convert headers back to ASGI spec
-                (key.lower().replace("_", "-").encode("latin-1"), value.encode("latin-1"))
-                for key, value in response.headers
-            ],
-        })
+        await send(
+            HTTPResponseStartEvent(
+                type="http.response.start",
+                status=int(response.status),
+                headers=[
+                    # Convert headers back to ASGI spec
+                    (key.lower().replace("_", "-").encode("latin-1"), value.encode("latin-1"))
+                    for key, value in response.headers
+                    if value is not None
+                ],
+                trailers=False,
+            )
+        )
 
         # Head responses have no body, so we terminate early
         if response.file is None:
-            await send({"type": "http.response.body", "body": b""})
+            await send(HTTPResponseBodyEvent(type="http.response.body", body=b"", more_body=False))
             return
 
         # Stream the file response body
-        async with response.file as async_file:
+        async with cast("AsyncFile | AsyncSlicedFile", response.file) as async_file:
             while True:
                 chunk = await async_file.read(self.block_size)
                 more_body = bool(chunk)
-                await send({
-                    "type": "http.response.body",
-                    "body": chunk,
-                    "more_body": more_body,
-                })
+                await send(HTTPResponseBodyEvent(type="http.response.body", body=chunk, more_body=more_body))
                 if not more_body:
                     break
 
@@ -94,16 +105,16 @@ class FileServerASGI:
 class NotFoundASGI:
     """ASGI v3 application that returns a 404 Not Found response."""
 
-    async def __call__(self, scope, receive, send) -> None:
+    async def __call__(self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         # Ensure this is an HTTP request
         if scope["type"] != "http":
             msg = "Default ASGI application only supports HTTP requests."
             raise RuntimeError(msg)
 
         # Send a 404 Not Found response
-        await send({
-            "type": "http.response.start",
-            "status": 404,
-            "headers": [(b"content-type", b"text/plain")],
-        })
-        await send({"type": "http.response.body", "body": b"Not Found"})
+        await send(
+            HTTPResponseStartEvent(
+                type="http.response.start", status=404, headers=[(b"content-type", b"text/plain")], trailers=False
+            )
+        )
+        await send(HTTPResponseBodyEvent(type="http.response.body", body=b"Not Found", more_body=False))

--- a/src/servestatic/base.py
+++ b/src/servestatic/base.py
@@ -18,7 +18,7 @@ from servestatic.responders import (
 from servestatic.utils import ensure_leading_trailing_slash, scantree
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 
@@ -52,9 +52,9 @@ class ServeStaticBase:
         mimetypes: dict[str, str] | None = None,
         add_headers_function: Callable[[Headers, str, str], None] | None = None,
         index_file: str | bool | None = None,
-        immutable_file_test: Callable | str | None = None,
+        immutable_file_test: Callable[[str, str], bool] | str | None = None,
         allow_unsafe_symlinks: bool = False,
-    ):
+    ) -> None:
         self.autorefresh = autorefresh
         self.max_age = max_age
         self.allow_all_origins = allow_all_origins
@@ -65,8 +65,8 @@ class ServeStaticBase:
         self.allow_unsafe_symlinks = allow_unsafe_symlinks
         self.media_types = MediaTypes(extra_types=mimetypes)
         self.application = application
-        self.files = {}
-        self.directories = []
+        self.files: dict[str, StaticFile | Redirect] = {}
+        self.directories: list[tuple[str, str]] = []
 
         if index_file is True:
             self.index_file: str | None = "index.html"
@@ -85,12 +85,13 @@ class ServeStaticBase:
 
         self.initialize()
 
-    def initialize(self):
+    def initialize(self) -> None:
         """Perform any necessary setup/initialization steps."""
         msg = "Subclasses must implement this method."
         raise NotImplementedError(msg)
 
-    def insert_directory(self, root, prefix):
+    def insert_directory(self, root: str | os.PathLike[str], prefix: str) -> None:
+        root = os.fspath(root)
         # Exit early if the directory is already in the list
         for existing_root, existing_prefix in self.directories:
             if existing_root == root and existing_prefix == prefix:
@@ -101,7 +102,7 @@ class ServeStaticBase:
         # match first when they're checked in "autorefresh" mode
         self.directories.insert(0, (root, prefix))
 
-    def add_files(self, root, prefix=None):
+    def add_files(self, root: str | os.PathLike[str], prefix: str | None = None) -> None:
         root = os.path.abspath(root)
         root = root.rstrip(os.path.sep) + os.path.sep
         prefix = ensure_leading_trailing_slash(prefix)
@@ -112,7 +113,7 @@ class ServeStaticBase:
         else:
             warnings.warn(f"No directory at: {root}", stacklevel=3)
 
-    def update_files_dictionary(self, root, prefix):
+    def update_files_dictionary(self, root: str, prefix: str) -> None:
         # Build a mapping from paths to the results of `os.stat` calls
         # so we only have to touch the filesystem once
         stat_cache = dict(scantree(root))
@@ -122,7 +123,13 @@ class ServeStaticBase:
             url = prefix + relative_url
             self.add_file_to_dictionary(url, path, root=root, stat_cache=stat_cache)
 
-    def add_file_to_dictionary(self, url, path, root=None, stat_cache=None):
+    def add_file_to_dictionary(
+        self,
+        url: str,
+        path: str,
+        root: str | os.PathLike[str] | None = None,
+        stat_cache: dict[str, os.stat_result] | None = None,
+    ) -> None:
         if root and not self.path_within_root(root, path):
             return
         if self.is_compressed_variant(path, stat_cache=stat_cache):
@@ -136,7 +143,7 @@ class ServeStaticBase:
         static_file = self.get_static_file(path, url, stat_cache=stat_cache)
         self.files[url] = static_file
 
-    def find_file(self, url):
+    def find_file(self, url: str) -> StaticFile | Redirect | None:
         # Optimization: bail early if the URL can never match a file
         if self.index_file is None and url.endswith("/"):
             return
@@ -147,14 +154,14 @@ class ServeStaticBase:
                 return self.find_file_at_path(path, url)
         return None
 
-    def candidate_paths_for_url(self, url):
+    def candidate_paths_for_url(self, url: str) -> Iterator[str]:
         for root, prefix in self.directories:
             if url.startswith(prefix):
                 path = os.path.join(root, url[len(prefix) :])
                 if self.path_within_root(root, path):
                     yield path
 
-    def path_within_root(self, root, path):
+    def path_within_root(self, root: str | os.PathLike[str], path: str | os.PathLike[str]) -> bool:
         normalized_root = os.path.normpath(os.fspath(root))
         normalized_path = os.path.normpath(os.fspath(path))
 
@@ -168,12 +175,12 @@ class ServeStaticBase:
         return self._path_is_within(resolved_root, resolved_path)
 
     @staticmethod
-    def _path_is_within(root, path):
+    def _path_is_within(root: str, path: str) -> bool:
         with contextlib.suppress(ValueError):
             return os.path.commonpath((root, path)) == root
         return False
 
-    def find_file_at_path(self, path, url):
+    def find_file_at_path(self, path: str, url: str) -> StaticFile | Redirect:
         if self.is_compressed_variant(path):
             raise MissingFileError(path)
 
@@ -195,7 +202,7 @@ class ServeStaticBase:
         return self.get_static_file(path, url)
 
     @staticmethod
-    def url_is_canonical(url):
+    def url_is_canonical(url: str) -> bool:
         """
         Check that the URL path is in canonical format i.e. has normalised
         slashes and no path traversal elements
@@ -208,7 +215,7 @@ class ServeStaticBase:
         return normalised == url
 
     @staticmethod
-    def is_compressed_variant(path, stat_cache=None):
+    def is_compressed_variant(path: str, stat_cache: dict[str, os.stat_result] | None = None) -> bool:
         for suffix in (".gz", ".br", ".zstd"):
             if path.endswith(suffix):
                 uncompressed_path = path[: -len(suffix)]
@@ -217,7 +224,7 @@ class ServeStaticBase:
                 return uncompressed_path in stat_cache
         return False
 
-    def get_static_file(self, path, url, stat_cache=None):
+    def get_static_file(self, path: str, url: str, stat_cache: dict[str, os.stat_result] | None = None) -> StaticFile:
         # Optimization: bail early if file does not exist
         if stat_cache is None and not os.path.exists(path):
             raise MissingFileError(path)
@@ -235,18 +242,18 @@ class ServeStaticBase:
             encodings={"zstd": f"{path}.zstd", "gzip": f"{path}.gz", "br": f"{path}.br"},
         )
 
-    def add_mime_headers(self, headers, path, url):
+    def add_mime_headers(self, headers: Headers, path: str, url: str) -> None:
         media_type = self.media_types.get_type(path)
         params = {"charset": str(self.charset)} if media_type.startswith("text/") else {}
         headers.add_header("Content-Type", str(media_type), **params)
 
-    def add_cache_headers(self, headers, path, url):
+    def add_cache_headers(self, headers: Headers, path: str, url: str) -> None:
         if self.immutable_file_test(path, url):
             headers["Cache-Control"] = f"max-age={self.FOREVER}, public, immutable"
         elif self.max_age is not None:
             headers["Cache-Control"] = f"max-age={self.max_age}, public"
 
-    def immutable_file_test(self, path, url):
+    def immutable_file_test(self, path: str, url: str) -> bool:
         """
         This should be implemented by sub-classes (see e.g. ServeStaticMiddleware)
         or by setting the `immutable_file_test` config option
@@ -257,7 +264,7 @@ class ServeStaticBase:
             return bool(self.user_immutable_file_test.search(url))
         return bool(self.DEFAULT_IMMUTABLE_FILE_TEST.search(url))
 
-    def redirect(self, from_url, to_url):
+    def redirect(self, from_url: str, to_url: str) -> Redirect:
         """
         Return a relative 302 redirect
 
@@ -265,8 +272,8 @@ class ServeStaticBase:
         being hosted under
         """
         if to_url == f"{from_url}/":
-            relative_url = from_url.split("/")[-1] + "/"
-        elif from_url == to_url + self.index_file:
+            relative_url = from_url.rsplit("/", maxsplit=1)[-1] + "/"
+        elif self.index_file is not None and from_url == to_url + self.index_file:
             relative_url = "./"
         else:
             msg = f"Cannot handle redirect: {from_url} > {to_url}"

--- a/src/servestatic/checks.py
+++ b/src/servestatic/checks.py
@@ -235,8 +235,6 @@ def check_setting_configuration(
     errors.extend(_validate_servestatic_charset())
     errors.extend(_validate_bool_setting("SERVESTATIC_ALLOW_ALL_ORIGINS", "servestatic.E018"))
     errors.extend(_validate_servestatic_skip_compress_extensions())
-    errors.extend(_validate_bool_setting("SERVESTATIC_USE_GZIP", "servestatic.E032"))
-    errors.extend(_validate_bool_setting("SERVESTATIC_USE_BROTLI", "servestatic.E033"))
     errors.extend(_validate_bool_setting("SERVESTATIC_USE_ZSTD", "servestatic.E020"))
     errors.extend(_validate_servestatic_zstd_dictionary())
     errors.extend(_validate_bool_setting("SERVESTATIC_ZSTD_DICTIONARY_IS_RAW", "servestatic.E022"))
@@ -249,5 +247,7 @@ def check_setting_configuration(
     errors.extend(_validate_bool_setting("SERVESTATIC_ALLOW_UNSAFE_SYMLINKS", "servestatic.E029"))
     errors.extend(_validate_bool_setting("SERVESTATIC_USE_STATIC_ROOT", "servestatic.E030"))
     errors.extend(_validate_bool_setting("SERVESTATIC_MINIFY", "servestatic.E031"))
+    errors.extend(_validate_bool_setting("SERVESTATIC_USE_GZIP", "servestatic.E032"))
+    errors.extend(_validate_bool_setting("SERVESTATIC_USE_BROTLI", "servestatic.E033"))
 
     return errors

--- a/src/servestatic/checks.py
+++ b/src/servestatic/checks.py
@@ -8,9 +8,13 @@ import os
 import re
 from collections.abc import Iterable, Mapping
 from importlib import import_module
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.checks import Error, register
+
+if TYPE_CHECKING:
+    from django.apps import AppConfig
 
 try:
     zstd = import_module("compression.zstd")
@@ -21,22 +25,24 @@ SERVESTATIC_MIDDLEWARE = "servestatic.middleware.ServeStaticMiddleware"
 GZIP_MIDDLEWARE = "django.middleware.gzip.GZipMiddleware"
 
 
-def _is_non_negative_int(value) -> bool:
+def _is_non_negative_int(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
-def _get_setting(name):
+def _get_setting(name: str) -> object | None:
     return getattr(settings, name, None)
 
 
-def _validate_type(name, *, expected, code, message):
+def _validate_type(
+    name: str, *, expected: type[object] | tuple[type[object], ...], code: str, message: str
+) -> list[Error]:
     value = _get_setting(name)
     if value is None:
         return []
     return [] if isinstance(value, expected) else [Error(message, id=code)]
 
 
-def _validate_bool_setting(name, code):
+def _validate_bool_setting(name: str, code: str) -> list[Error]:
     return _validate_type(
         name,
         expected=bool,
@@ -45,7 +51,7 @@ def _validate_bool_setting(name, code):
     )
 
 
-def _validate_servestatic_root():
+def _validate_servestatic_root() -> list[Error]:
     value = _get_setting("SERVESTATIC_ROOT")
     if value is None:
         return []
@@ -54,14 +60,14 @@ def _validate_servestatic_root():
     return [Error("SERVESTATIC_ROOT must be a string path, os.PathLike, or None.", id="servestatic.E010")]
 
 
-def _validate_servestatic_max_age():
+def _validate_servestatic_max_age() -> list[Error]:
     value = _get_setting("SERVESTATIC_MAX_AGE")
     if value is None or _is_non_negative_int(value):
         return []
     return [Error("SERVESTATIC_MAX_AGE must be a non-negative integer or None.", id="servestatic.E014")]
 
 
-def _validate_servestatic_index_file():
+def _validate_servestatic_index_file() -> list[Error]:
     value = _get_setting("SERVESTATIC_INDEX_FILE")
     if value is None or isinstance(value, bool):
         return []
@@ -75,7 +81,7 @@ def _validate_servestatic_index_file():
     ]
 
 
-def _validate_servestatic_mimetypes():
+def _validate_servestatic_mimetypes() -> list[Error]:
     value = _get_setting("SERVESTATIC_MIMETYPES")
     if value is None:
         return []
@@ -91,14 +97,14 @@ def _validate_servestatic_mimetypes():
     return []
 
 
-def _validate_servestatic_charset():
+def _validate_servestatic_charset() -> list[Error]:
     value = _get_setting("SERVESTATIC_CHARSET")
     if value is None or (isinstance(value, str) and value):
         return []
     return [Error("SERVESTATIC_CHARSET must be a non-empty string.", id="servestatic.E017")]
 
 
-def _validate_servestatic_skip_compress_extensions():
+def _validate_servestatic_skip_compress_extensions() -> list[Error]:
     value = _get_setting("SERVESTATIC_SKIP_COMPRESS_EXTENSIONS")
     if value is None:
         return []
@@ -112,7 +118,7 @@ def _validate_servestatic_skip_compress_extensions():
     return []
 
 
-def _validate_servestatic_zstd_dictionary():
+def _validate_servestatic_zstd_dictionary() -> list[Error]:
     value = _get_setting("SERVESTATIC_ZSTD_DICTIONARY")
     if value is None:
         return []
@@ -128,7 +134,7 @@ def _validate_servestatic_zstd_dictionary():
     ]
 
 
-def _validate_servestatic_zstd_level():
+def _validate_servestatic_zstd_level() -> list[Error]:
     value = _get_setting("SERVESTATIC_ZSTD_LEVEL")
     if value is None:
         return []
@@ -137,14 +143,14 @@ def _validate_servestatic_zstd_level():
     return [Error("SERVESTATIC_ZSTD_LEVEL must be an integer or None.", id="servestatic.E023")]
 
 
-def _validate_servestatic_add_headers_function():
+def _validate_servestatic_add_headers_function() -> list[Error]:
     value = _get_setting("SERVESTATIC_ADD_HEADERS_FUNCTION")
     if value is None or callable(value):
         return []
     return [Error("SERVESTATIC_ADD_HEADERS_FUNCTION must be callable or None.", id="servestatic.E024")]
 
 
-def _validate_servestatic_immutable_file_test():
+def _validate_servestatic_immutable_file_test() -> list[Error]:
     value = _get_setting("SERVESTATIC_IMMUTABLE_FILE_TEST")
     if value is None or callable(value):
         return []
@@ -157,7 +163,7 @@ def _validate_servestatic_immutable_file_test():
     return [Error("SERVESTATIC_IMMUTABLE_FILE_TEST must be callable, regex string, or None.", id="servestatic.E025")]
 
 
-def _validate_servestatic_static_prefix():
+def _validate_servestatic_static_prefix() -> list[Error]:
     value = _get_setting("SERVESTATIC_STATIC_PREFIX")
     if value is None or isinstance(value, str):
         return []
@@ -165,7 +171,10 @@ def _validate_servestatic_static_prefix():
 
 
 @register()
-def check_middleware_configuration(app_configs, **kwargs):
+def check_middleware_configuration(
+    app_configs: Iterable[AppConfig] | None = None,
+    **kwargs: object,
+) -> list[Error]:
     middleware = list(getattr(settings, "MIDDLEWARE", []))
 
     if SERVESTATIC_MIDDLEWARE not in middleware or GZIP_MIDDLEWARE not in middleware:
@@ -187,7 +196,10 @@ def check_middleware_configuration(app_configs, **kwargs):
 
 
 @register()
-def check_setting_configuration(app_configs, **kwargs):
+def check_setting_configuration(
+    app_configs: Iterable[AppConfig] | None = None,
+    **kwargs: object,
+) -> list[Error]:
     errors = []
 
     errors.extend(_validate_servestatic_root())

--- a/src/servestatic/checks.py
+++ b/src/servestatic/checks.py
@@ -245,5 +245,6 @@ def check_setting_configuration(
     errors.extend(_validate_bool_setting("SERVESTATIC_KEEP_ONLY_HASHED_FILES", "servestatic.E027"))
     errors.extend(_validate_bool_setting("SERVESTATIC_MANIFEST_STRICT", "servestatic.E028"))
     errors.extend(_validate_bool_setting("SERVESTATIC_ALLOW_UNSAFE_SYMLINKS", "servestatic.E029"))
+    errors.extend(_validate_bool_setting("SERVESTATIC_USE_STATIC_ROOT", "servestatic.E030"))
 
     return errors

--- a/src/servestatic/checks.py
+++ b/src/servestatic/checks.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.core.checks import Error, register
+from django.core.checks import Warning as CheckWarning
 
 if TYPE_CHECKING:
     from django.apps import AppConfig
@@ -23,6 +24,10 @@ except ImportError:  # pragma: no cover
 
 SERVESTATIC_MIDDLEWARE = "servestatic.middleware.ServeStaticMiddleware"
 GZIP_MIDDLEWARE = "django.middleware.gzip.GZipMiddleware"
+LEGACY_SERVESTATIC_APPS = {
+    "servestatic.runserver_nostatic",
+    "servestatic.runserver_nostatic.apps.ServeStaticRunserverNoStaticAliasConfig",
+}
 
 
 def _is_non_negative_int(value: object) -> bool:
@@ -191,6 +196,24 @@ def check_middleware_configuration(
                 "'django.middleware.gzip.GZipMiddleware' in MIDDLEWARE."
             ),
             id="servestatic.E001",
+        )
+    ]
+
+
+@register()
+def check_deprecated_app_configuration(
+    app_configs: Iterable[AppConfig] | None = None,
+    **kwargs: object,
+) -> list[CheckWarning]:
+    installed_apps = set(getattr(settings, "INSTALLED_APPS", []))
+    if not installed_apps.intersection(LEGACY_SERVESTATIC_APPS):
+        return []
+
+    return [
+        CheckWarning(
+            "Deprecated ServeStatic app path detected.",
+            hint="Replace 'servestatic.runserver_nostatic' with 'servestatic' in INSTALLED_APPS.",
+            id="servestatic.W001",
         )
     ]
 

--- a/src/servestatic/checks.py
+++ b/src/servestatic/checks.py
@@ -235,6 +235,8 @@ def check_setting_configuration(
     errors.extend(_validate_servestatic_charset())
     errors.extend(_validate_bool_setting("SERVESTATIC_ALLOW_ALL_ORIGINS", "servestatic.E018"))
     errors.extend(_validate_servestatic_skip_compress_extensions())
+    errors.extend(_validate_bool_setting("SERVESTATIC_USE_GZIP", "servestatic.E032"))
+    errors.extend(_validate_bool_setting("SERVESTATIC_USE_BROTLI", "servestatic.E033"))
     errors.extend(_validate_bool_setting("SERVESTATIC_USE_ZSTD", "servestatic.E020"))
     errors.extend(_validate_servestatic_zstd_dictionary())
     errors.extend(_validate_bool_setting("SERVESTATIC_ZSTD_DICTIONARY_IS_RAW", "servestatic.E022"))
@@ -246,5 +248,6 @@ def check_setting_configuration(
     errors.extend(_validate_bool_setting("SERVESTATIC_MANIFEST_STRICT", "servestatic.E028"))
     errors.extend(_validate_bool_setting("SERVESTATIC_ALLOW_UNSAFE_SYMLINKS", "servestatic.E029"))
     errors.extend(_validate_bool_setting("SERVESTATIC_USE_STATIC_ROOT", "servestatic.E030"))
+    errors.extend(_validate_bool_setting("SERVESTATIC_MINIFY", "servestatic.E031"))
 
     return errors

--- a/src/servestatic/cli.py
+++ b/src/servestatic/cli.py
@@ -12,7 +12,7 @@ from servestatic.compress import Compressor
 from servestatic.manifest_hash import ManifestHashGenerator
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Process static files: copy, optionally hash, and compress.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/src/servestatic/cli.py
+++ b/src/servestatic/cli.py
@@ -17,6 +17,8 @@ def main(argv: list[str] | None = None) -> int:
         description="Process static files: copy, optionally hash, and compress.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+
+    # Operation flags
     parser.add_argument(
         "--all",
         action="store_true",
@@ -33,11 +35,6 @@ def main(argv: list[str] | None = None) -> int:
         help="Generate a manifest file (staticfiles.json).",
     )
     parser.add_argument(
-        "--merge-manifest",
-        action="store_true",
-        help="Merge the new manifest with an existing manifest in the dest directory. Fails if the existing manifest is not found.",
-    )
-    parser.add_argument(
         "--compress",
         action="store_true",
         help="Generate compressed versions (gzip/zstd/brotli) of files.",
@@ -47,12 +44,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Empty the destination directory before processing.",
     )
-    parser.add_argument("-q", "--quiet", action="store_true", help="Don't produce log output.")
+    parser.add_argument(
+        "--merge-manifest",
+        action="store_true",
+        help="Merge the new manifest with an existing manifest in the dest directory. Fails if the existing manifest is not found.",
+    )
     parser.add_argument(
         "--copy-original",
         action="store_true",
         help="Copy the original unhashed files into the dest directory alongside the hashed versions (only applies with --hash).",
     )
+
     # Compression specific flags
     parser.add_argument(
         "--no-gzip",
@@ -86,13 +88,17 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         help="Compression level for zstd output (only applies with --compress).",
     )
-    # Exclusion
+
+    # General flags
+    parser.add_argument("-q", "--quiet", action="store_true", help="Don't produce log output.")
     parser.add_argument(
         "-e",
         "--exclude",
         action="append",
         help="Glob pattern(s) to exclude from processing (compression/hashing). These files are still copied.",
     )
+
+    # Positional arguments
     parser.add_argument("src", help="Source directory containing static files.")
     parser.add_argument("dest", help="Destination directory for processed files.")
 

--- a/src/servestatic/cli.py
+++ b/src/servestatic/cli.py
@@ -40,6 +40,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Generate compressed versions (gzip/zstd/brotli) of files.",
     )
     parser.add_argument(
+        "--minify",
+        action="store_true",
+        help="Minify CSS and JS files.",
+    )
+    parser.add_argument(
         "--clear",
         action="store_true",
         help="Empty the destination directory before processing.",
@@ -248,6 +253,7 @@ def main(argv: list[str] | None = None) -> int:
             zstd_dict=args.zstd_dict,
             zstd_dict_is_raw=args.zstd_dict_raw,
             zstd_level=args.zstd_level,
+            minify=args.minify,
             quiet=args.quiet,
             log=log,
             # We explicitly rely on the compressor class's default extension exclusion filter

--- a/src/servestatic/compress.py
+++ b/src/servestatic/compress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import gzip
 import os
 import re
@@ -21,6 +22,16 @@ try:
     zstd = import_module("compression.zstd")
 except ImportError:  # pragma: no cover
     zstd = None
+
+try:
+    import rcssmin  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    rcssmin = None
+
+try:
+    import rjsmin  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    rjsmin = None
 
 
 class Compressor:
@@ -69,6 +80,7 @@ class Compressor:
         use_gzip: bool = True,
         use_brotli: bool = True,
         use_zstd: bool = True,
+        minify: bool = False,
         zstd_dict: str | os.PathLike[str] | bytes | bytearray | memoryview | object | None = None,
         zstd_dict_is_raw: bool = False,
         zstd_level: int | None = None,
@@ -94,6 +106,10 @@ class Compressor:
         self.zstd_level = zstd_level
         self.zstd_dict = self.load_zstd_dictionary(zstd_dict, is_raw=zstd_dict_is_raw)
         self.log = logger
+        self.minify = minify
+        if self.minify and (rcssmin is None or rjsmin is None):
+            error_msg = "Minification requested but rcssmin or rjsmin is not installed."
+            raise ImportError(error_msg)
 
     @staticmethod
     def load_zstd_dictionary(
@@ -129,19 +145,31 @@ class Compressor:
         with open(path, "rb") as f:
             stat_result = os.fstat(f.fileno())
             data = f.read()
+
+        if self.minify:
+            if path.endswith(".css"):
+                with contextlib.suppress(UnicodeDecodeError):
+                    data = rcssmin.cssmin(data.decode("utf-8")).encode("utf-8")  # type: ignore
+            elif path.endswith(".js"):
+                with contextlib.suppress(UnicodeDecodeError):
+                    data = rjsmin.jsmin(data.decode("utf-8")).encode("utf-8")  # type: ignore
+
         size = len(data)
         if self.use_zstd:
             compressed = self.compress_zstd(data, level=self.zstd_level, zstd_dict=self.zstd_dict)
             if self.is_compressed_effectively("Zstandard", path, size, compressed):
                 filenames.append(self.write_data(path, compressed, ".zstd", stat_result))
+
         if self.use_brotli:
             compressed = self.compress_brotli(data)
             if self.is_compressed_effectively("Brotli", path, size, compressed):
                 filenames.append(self.write_data(path, compressed, ".br", stat_result))
+
         if self.use_gzip:
             compressed = self.compress_gzip(data)
             if self.is_compressed_effectively("Gzip", path, size, compressed):
                 filenames.append(self.write_data(path, compressed, ".gz", stat_result))
+
         return filenames
 
     @staticmethod

--- a/src/servestatic/compress.py
+++ b/src/servestatic/compress.py
@@ -7,6 +7,10 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from importlib import import_module
 from io import BytesIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 try:
     import brotli
@@ -61,16 +65,16 @@ class Compressor:
 
     def __init__(
         self,
-        extensions=None,
-        use_gzip=True,
-        use_brotli=True,
-        use_zstd=True,
-        zstd_dict=None,
-        zstd_dict_is_raw=False,
-        zstd_level=None,
-        log=print,
-        quiet=False,
-    ):
+        extensions: Iterable[str] | None = None,
+        use_gzip: bool = True,
+        use_brotli: bool = True,
+        use_zstd: bool = True,
+        zstd_dict: str | os.PathLike[str] | bytes | bytearray | memoryview | object | None = None,
+        zstd_dict_is_raw: bool = False,
+        zstd_level: int | None = None,
+        log: Callable[[str], None] = print,
+        quiet: bool = False,
+    ) -> None:
         if extensions is None:
             extensions = self.SKIP_COMPRESS_EXTENSIONS
         self.extension_re = self.get_extension_re(extensions)
@@ -85,7 +89,11 @@ class Compressor:
         self.log = (lambda _: None) if quiet else log
 
     @staticmethod
-    def load_zstd_dictionary(zstd_dict, *, is_raw=False):
+    def load_zstd_dictionary(
+        zstd_dict: str | os.PathLike[str] | bytes | bytearray | memoryview | object | None,
+        *,
+        is_raw: bool = False,
+    ) -> object | None:
         if zstd_dict is None:
             return None
         if zstd is None:
@@ -100,15 +108,16 @@ class Compressor:
         return zstd_dict
 
     @staticmethod
-    def get_extension_re(extensions):
+    def get_extension_re(extensions: Iterable[str]) -> re.Pattern[str]:
         if not extensions:
             return re.compile(r"^$")
         return re.compile(rf"\.({'|'.join(map(re.escape, extensions))})$", re.IGNORECASE)
 
-    def should_compress(self, filename):
+    def should_compress(self, filename: str) -> bool:
         return not self.extension_re.search(filename)
 
-    def compress(self, path):
+    def compress(self, path: str | os.PathLike[str]) -> list[str]:
+        path = os.fspath(path)
         filenames = []
         with open(path, "rb") as f:
             stat_result = os.fstat(f.fileno())
@@ -129,7 +138,7 @@ class Compressor:
         return filenames
 
     @staticmethod
-    def compress_gzip(data):
+    def compress_gzip(data: bytes) -> bytes:
         output = BytesIO()
         # Explicitly set mtime to 0 so gzip content is fully determined
         # by file content (0 = "no timestamp" according to gzip spec)
@@ -138,14 +147,14 @@ class Compressor:
         return output.getvalue()
 
     @staticmethod
-    def compress_brotli(data):
+    def compress_brotli(data: bytes) -> bytes:
         if brotli is None:
             msg = "Brotli is not installed"
             raise RuntimeError(msg)
         return brotli.compress(data)
 
     @staticmethod
-    def compress_zstd(data, level=None, zstd_dict=None):
+    def compress_zstd(data: bytes, level: int | None = None, zstd_dict: object | None = None) -> bytes:
         if zstd is None:
             msg = "Zstandard is not available"
             raise RuntimeError(msg)
@@ -156,7 +165,7 @@ class Compressor:
             kwargs["zstd_dict"] = zstd_dict
         return zstd.compress(data, **kwargs)
 
-    def is_compressed_effectively(self, encoding_name, path, orig_size, data):
+    def is_compressed_effectively(self, encoding_name: str, path: str, orig_size: int, data: bytes) -> bool:
         compressed_size = len(data)
         if orig_size == 0:
             is_effective = False
@@ -170,7 +179,7 @@ class Compressor:
         return is_effective
 
     @staticmethod
-    def write_data(path, data, suffix, stat_result):
+    def write_data(path: str, data: bytes, suffix: str, stat_result: os.stat_result) -> str:
         filename = path + suffix
         with open(filename, "wb") as f:
             f.write(data)
@@ -178,7 +187,7 @@ class Compressor:
         return filename
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Search for all files inside <root> *not* matching "
         "<extensions> and produce compressed versions with "

--- a/src/servestatic/compress.py
+++ b/src/servestatic/compress.py
@@ -75,18 +75,25 @@ class Compressor:
         log: Callable[[str], None] = print,
         quiet: bool = False,
     ) -> None:
+        logger = (lambda _: None) if quiet else log
         if extensions is None:
             extensions = self.SKIP_COMPRESS_EXTENSIONS
         self.extension_re = self.get_extension_re(extensions)
         self.use_gzip = use_gzip
+        if use_brotli and brotli is None:
+            logger("Warning: Brotli compression requested but brotli is not installed. Skipping Brotli output.")
         self.use_brotli = use_brotli and (brotli is not None)
+        if use_zstd and zstd is None:
+            logger(
+                "Warning: Zstandard compression requested but compression.zstd is unavailable. Skipping Zstandard output."
+            )
         if zstd_dict is not None and zstd is None:
             msg = "Zstandard dictionary support requires Python 3.14+ with compression.zstd available"
             raise RuntimeError(msg)
         self.use_zstd = use_zstd and (zstd is not None)
         self.zstd_level = zstd_level
         self.zstd_dict = self.load_zstd_dictionary(zstd_dict, is_raw=zstd_dict_is_raw)
-        self.log = (lambda _: None) if quiet else log
+        self.log = logger
 
     @staticmethod
     def load_zstd_dictionary(

--- a/src/servestatic/compress.py
+++ b/src/servestatic/compress.py
@@ -174,11 +174,7 @@ class Compressor:
 
     def is_compressed_effectively(self, encoding_name: str, path: str, orig_size: int, data: bytes) -> bool:
         compressed_size = len(data)
-        if orig_size == 0:
-            is_effective = False
-        else:
-            ratio = compressed_size / orig_size
-            is_effective = ratio <= 0.95
+        is_effective = False if orig_size == 0 else compressed_size / orig_size <= 0.95
         if is_effective:
             self.log(f"{encoding_name} compressed {path} ({orig_size // 1024}K -> {compressed_size // 1024}K)")
         else:
@@ -273,6 +269,8 @@ def main(argv: list[str] | None = None) -> int:
 if __name__ == "__main__":  # pragma: no cover
     from warnings import warn
 
+    # Note: To simplify WhiteNoise -> ServeStatic migration, the capability to run this file directly will be retained long-term,
+    # but it is not recommended. Future updates will be made to our new CLI, and not to this interface.
     warn(
         "Calling this file directly is deprecated. Use the 'servestatic --compress' command instead.",
         DeprecationWarning,

--- a/src/servestatic/management/commands/runserver.py
+++ b/src/servestatic/management/commands/runserver.py
@@ -16,12 +16,14 @@ from typing import TYPE_CHECKING, cast
 from django.apps import apps
 
 if TYPE_CHECKING:
-    from django.core.management.base import BaseCommand
+    from collections.abc import Iterator
+
+    from django.core.management.base import BaseCommand, CommandParser
 
 SERVESTATIC_APP_NAME = "servestatic"
 
 
-def find_fallback_runserver_command():
+def find_fallback_runserver_command() -> type[BaseCommand] | None:
     """
     Return the next highest priority "runserver" command class.
     """
@@ -32,7 +34,7 @@ def find_fallback_runserver_command():
     return None
 
 
-def iter_lower_priority_apps():
+def iter_lower_priority_apps() -> Iterator[str]:
     """
     Yield all app module names below the current app in INSTALLED_APPS.
     """
@@ -49,7 +51,7 @@ BaseRunserverCommand = cast("type[BaseCommand]", find_fallback_runserver_command
 
 
 class Command(BaseRunserverCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         super().add_arguments(parser)
         if not parser.description:
             parser.description = ""

--- a/src/servestatic/manifest_hash.py
+++ b/src/servestatic/manifest_hash.py
@@ -4,6 +4,10 @@ import hashlib
 import os
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def generate_hash(content: bytes) -> str:
@@ -38,7 +42,9 @@ def get_hashed_name(path: str | Path, content: bytes | None = None) -> str:
 
 
 class ManifestHashGenerator:
-    def __init__(self, root: str | Path, keep_original=True, log=print, quiet=False):
+    def __init__(
+        self, root: str | Path, keep_original: bool = True, log: Callable[[str], None] = print, quiet: bool = False
+    ) -> None:
         self.root = Path(root).resolve()
         self.keep_original = keep_original
         self.log = (lambda _: None) if quiet else log

--- a/src/servestatic/middleware.py
+++ b/src/servestatic/middleware.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import os
 import warnings
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable, Iterator
 from inspect import iscoroutinefunction
 from posixpath import basename, normpath
 from typing import cast
@@ -12,13 +12,14 @@ from urllib.parse import urlparse
 from urllib.request import url2pathname
 
 from asgiref.sync import markcoroutinefunction
+from django.conf import LazySettings
 from django.conf import settings as django_settings
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import (
     ManifestStaticFilesStorage,
     staticfiles_storage,
 )
-from django.http import FileResponse, HttpRequest
+from django.http import FileResponse, HttpRequest, HttpResponseBase
 
 from servestatic.responders import AsyncSlicedFile, MissingFileError, Redirect, StaticFile
 from servestatic.storage import CompressedManifestStaticFilesStorage
@@ -34,7 +35,7 @@ from servestatic.wsgi import ServeStaticBase
 
 __all__ = ["ServeStaticMiddleware"]
 
-GetResponseCallable = Callable[[HttpRequest], Awaitable[object]]
+GetResponseCallable = Callable[[HttpRequest], Awaitable[HttpResponseBase]]
 
 SERVESTATIC_APP_PATHS = frozenset({
     "servestatic",
@@ -44,15 +45,17 @@ SERVESTATIC_APP_PATHS = frozenset({
 })
 
 
-def has_servestatic_app(installed_apps) -> bool:
+def has_servestatic_app(installed_apps: Iterable[str]) -> bool:
     return bool(set(installed_apps) & SERVESTATIC_APP_PATHS)
 
 
-def is_async_callable(value) -> bool:
+def is_async_callable(value: object) -> bool:
     return iscoroutinefunction(value) or (callable(value) and iscoroutinefunction(value.__call__))
 
 
-def finder_path_is_allowed(directories, url, path, path_within_root) -> bool:
+def finder_path_is_allowed(
+    directories: list[tuple[str, str]], url: str, path: str, path_within_root: Callable[[str, str], bool]
+) -> bool:
     return any(root and url.startswith(prefix) and path_within_root(root, path) for root, prefix in directories)
 
 
@@ -66,7 +69,9 @@ class ServeStaticMiddleware(ServeStaticBase):
     sync_capable = False
     get_response: GetResponseCallable
 
-    def __init__(self, get_response=None, settings=django_settings):
+    def __init__(
+        self, get_response: GetResponseCallable | None = None, settings: LazySettings = django_settings
+    ) -> None:
         if not is_async_callable(get_response):
             msg = "ServeStaticMiddleware requires an async compatible version of Django."
             raise ValueError(msg)
@@ -138,7 +143,7 @@ class ServeStaticMiddleware(ServeStaticBase):
         if root:
             self.add_files(root)
 
-    async def __call__(self, request):
+    async def __call__(self, request: HttpRequest) -> HttpResponseBase:
         """If the URL contains a static file, serve it. Otherwise, continue to the next
         middleware."""
         if self.autorefresh:
@@ -159,8 +164,8 @@ class ServeStaticMiddleware(ServeStaticBase):
         return await self.get_response(request)
 
     @staticmethod
-    async def aserve(static_file: StaticFile | Redirect, request: HttpRequest):
-        response = await static_file.aget_response(request.method, request.META)
+    async def aserve(static_file: StaticFile | Redirect, request: HttpRequest) -> AsyncServeStaticFileResponse:
+        response = await static_file.aget_response(request.method or "GET", request.META)
         status = int(response.status)
         http_response = AsyncServeStaticFileResponse(
             response.file or EmptyAsyncIterator(),
@@ -169,10 +174,11 @@ class ServeStaticMiddleware(ServeStaticBase):
         # Remove default content-type
         del http_response["content-type"]
         for key, value in response.headers:
-            http_response[key] = value
+            if value is not None:
+                http_response[key] = value
         return http_response
 
-    def add_files_from_finders(self):
+    def add_files_from_finders(self) -> None:
         files: dict[str, tuple[str, str | None]] = {}
         for finder in finders.get_finders():
             for path, storage in finder.list(None):
@@ -191,7 +197,7 @@ class ServeStaticMiddleware(ServeStaticBase):
         for url, (path, root) in files.items():
             self.add_file_to_dictionary(url, path, root=root, stat_cache=stat_cache)
 
-    def add_files_from_manifest(self):
+    def add_files_from_manifest(self) -> None:
         if not isinstance(staticfiles_storage, ManifestStaticFilesStorage):
             msg = "SERVESTATIC_USE_MANIFEST is set to True but staticfiles storage is not using a manifest."
             raise TypeError(msg)
@@ -200,7 +206,7 @@ class ServeStaticMiddleware(ServeStaticBase):
         # Fetch `stat_cache` from the manifest file, if possible
         stat_cache = None
         if isinstance(staticfiles_storage, CompressedManifestStaticFilesStorage):
-            manifest_stats: dict = staticfiles_storage.load_manifest_stats()
+            manifest_stats: dict[str, list[int] | tuple[int, ...]] = staticfiles_storage.load_manifest_stats()
             if manifest_stats:
                 stat_cache = {staticfiles_storage.path(k): os.stat_result(v) for k, v in manifest_stats.items()}
 
@@ -226,7 +232,7 @@ class ServeStaticMiddleware(ServeStaticBase):
         if staticfiles_storage.location:
             self.insert_directory(staticfiles_storage.location, self.static_prefix)
 
-    def candidate_paths_for_url(self, url):
+    def candidate_paths_for_url(self, url: str) -> Iterator[str]:
         if self.use_finders and url.startswith(self.static_prefix):
             relative_url = url[len(self.static_prefix) :]
             path = url2pathname(relative_url)
@@ -236,7 +242,7 @@ class ServeStaticMiddleware(ServeStaticBase):
                 yield path
         yield from super().candidate_paths_for_url(url)
 
-    def immutable_file_test(self, path, url):
+    def immutable_file_test(self, path: str, url: str) -> bool:
         """
         Determine whether given URL represents an immutable file (i.e. a
         file with a hash of its contents as part of its name) which can
@@ -255,7 +261,7 @@ class ServeStaticMiddleware(ServeStaticBase):
         return bool(static_url and basename(static_url) == basename(url))
 
     @staticmethod
-    def get_name_without_hash(filename):
+    def get_name_without_hash(filename: str) -> str:
         """
         Removes the version hash from a filename e.g, transforms
         'css/application.f3ea4bcc2.css' into 'css/application.css'
@@ -269,12 +275,13 @@ class ServeStaticMiddleware(ServeStaticBase):
         return name + ext
 
     @staticmethod
-    def get_static_url(name):
+    def get_static_url(name: str) -> str | None:
         with contextlib.suppress(ValueError):
             return staticfiles_storage.url(name)
+        return None
 
     @staticmethod
-    def default_static_prefix(settings) -> str:
+    def default_static_prefix(settings: LazySettings) -> str:
         force_script_name = getattr(settings, "FORCE_SCRIPT_NAME", None)
         static_url = getattr(settings, "STATIC_URL", None)
         static_prefix = urlparse(static_url or "").path
@@ -295,10 +302,10 @@ class AsyncServeStaticFileResponse(FileResponse):
     - Enables async compatibility.
     """
 
-    def set_headers(self, *args, **kwargs):
+    def set_headers(self, *args: object, **kwargs: object) -> None:
         pass
 
-    def _set_streaming_content(self, value):
+    def _set_streaming_content(self, value: object) -> None:
         # Django 4.2+ supports async file responses, but they need to be converted from
         # a file-like object to an iterator, otherwise Django will assume the content is
         # a traditional (sync) file object.
@@ -307,7 +314,7 @@ class AsyncServeStaticFileResponse(FileResponse):
 
         super()._set_streaming_content(value)  # pyright: ignore [reportAttributeAccessIssue]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[bytes]:
         """The way that Django 4.2+ converts async to sync is inefficient, so
         we override it with a better implementation. Django only uses this method
         when running via WSGI."""

--- a/src/servestatic/middleware.py
+++ b/src/servestatic/middleware.py
@@ -102,6 +102,9 @@ class ServeStaticMiddleware(ServeStaticBase):
             "SERVESTATIC_USE_MANIFEST",
             not debug and isinstance(staticfiles_storage, ManifestStaticFilesStorage),
         )
+        self.use_static_root = getattr(
+            settings, "SERVESTATIC_USE_STATIC_ROOT", not (self.use_manifest or self.use_finders)
+        )
         self.static_prefix: str = getattr(settings, "SERVESTATIC_STATIC_PREFIX", self.default_static_prefix(settings))
         self.static_root = getattr(settings, "STATIC_ROOT", None)
         self.keep_only_hashed_files = getattr(django_settings, "SERVESTATIC_KEEP_ONLY_HASHED_FILES", False)
@@ -123,12 +126,17 @@ class ServeStaticMiddleware(ServeStaticBase):
         # Set the static prefix
         self.static_prefix = ensure_leading_trailing_slash(self.static_prefix)
 
-        # Add the files from STATIC_ROOT, if needed
+        # Recognize the static root as a directory we are allowed to serve from
         if self.static_root:
             self.static_root = os.path.abspath(self.static_root)
             self.insert_directory(self.static_root, self.static_prefix)
 
-            if not self.use_manifest and not self.use_finders:
+        # Add the files from STATIC_ROOT, if needed
+        if self.use_static_root:
+            if not self.static_root:  # nocov
+                msg = "SERVESTATIC_USE_STATIC_ROOT is set to True but STATIC_ROOT is not configured."
+                warnings.warn(msg, stacklevel=2)
+            else:
                 self.add_files(self.static_root, prefix=self.static_prefix)
 
         # Add files from the manifest, if needed

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -9,16 +9,25 @@ from email.utils import formatdate, parsedate
 from http import HTTPStatus
 from io import BufferedIOBase
 from time import mktime
+from typing import TYPE_CHECKING, Self
 from urllib.parse import quote
 from wsgiref.headers import Headers
 
 from servestatic.utils import AsyncFile
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
-class Response:
+
+class Response:  # noqa: B903
     __slots__ = ("file", "headers", "status")
 
-    def __init__(self, status, headers, file):
+    def __init__(
+        self,
+        status: HTTPStatus,
+        headers: list[tuple[str, str | None]],
+        file: BufferedIOBase | AsyncFile | AsyncSlicedFile | None,
+    ) -> None:
         self.status = status
         self.headers = headers
         self.file = file
@@ -49,14 +58,14 @@ class SlicedFile(BufferedIOBase):
     been reached.
     """
 
-    def __init__(self, fileobj: BufferedIOBase, start: int, end: int):
+    def __init__(self, fileobj: BufferedIOBase, start: int, end: int) -> None:
         self.fileobj = fileobj
         self.seeked = False
         self.start = start
         self.end = end
         self.remaining = end - start + 1
 
-    def read(self, size=-1):  # pyright: ignore [reportIncompatibleMethodOverride]
+    def read(self, size: int = -1) -> bytes:  # pyright: ignore [reportIncompatibleMethodOverride]
         if not self.seeked:
             self.fileobj.seek(self.start)
             self.seeked = True
@@ -67,7 +76,7 @@ class SlicedFile(BufferedIOBase):
         self.remaining -= len(data)
         return data
 
-    def close(self):
+    def close(self) -> None:
         super().close()
         self.fileobj.close()
 
@@ -77,14 +86,14 @@ class AsyncSlicedFile:
     Variant of `SlicedFile` that works on async files.
     """
 
-    def __init__(self, fileobj: AsyncFile, start: int, end: int):
+    def __init__(self, fileobj: AsyncFile, start: int, end: int) -> None:
         self.fileobj = fileobj
         self.seeked = False
         self.start = start
         self.end = end
         self.remaining = end - start + 1
 
-    async def read(self, size=-1):
+    async def read(self, size: int = -1) -> bytes:
         if not self.seeked:
             await self.fileobj.seek(self.start)
             self.seeked = True
@@ -95,26 +104,32 @@ class AsyncSlicedFile:
         self.remaining -= len(data)
         return data
 
-    async def close(self):
+    async def close(self) -> None:
         await self.fileobj.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Self:
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         await self.close()
 
 
 class StaticFile:
-    def __init__(self, path, headers, encodings=None, stat_cache=None):
+    def __init__(
+        self,
+        path: str,
+        headers: list[tuple[str, str]],
+        encodings: Mapping[str, str] | None = None,
+        stat_cache: Mapping[str, os.stat_result] | None = None,
+    ) -> None:
         files = self.get_file_stats(path, encodings, stat_cache)
-        headers = self.get_headers(headers, files)
-        self.last_modified = parsedate(headers["Last-Modified"])
-        self.etag = headers["ETag"]
-        self.not_modified_response = self.get_not_modified_response(headers)
-        self.alternatives = self.get_alternatives(headers, files)
+        headers_obj = self.get_headers(headers, files)
+        self.last_modified = parsedate(headers_obj["Last-Modified"])
+        self.etag = headers_obj["ETag"]
+        self.not_modified_response = self.get_not_modified_response(headers_obj)
+        self.alternatives = self.get_alternatives(headers_obj, files)
 
-    def get_response(self, method, request_headers):
+    def get_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
         if method not in {"GET", "HEAD"}:
             return NOT_ALLOWED_RESPONSE
         if self.is_not_modified(request_headers):
@@ -130,7 +145,7 @@ class StaticFile:
                 return self.get_range_response(range_header, headers, file_handle)
         return Response(HTTPStatus.OK, headers, file_handle)
 
-    async def aget_response(self, method, request_headers):
+    async def aget_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
         """Variant of `get_response` that works with async HTTP requests.
         To minimize code duplication, `request_headers` conforms to WSGI header spec."""
         if method not in {"GET", "HEAD"}:
@@ -150,12 +165,18 @@ class StaticFile:
                 return await self.aget_range_response(range_header, headers, file_handle)
         return Response(HTTPStatus.OK, headers, file_handle)
 
-    def get_range_response(self, range_header, base_headers, file_handle):
-        headers = []
+    def get_range_response(
+        self,
+        range_header: str,
+        base_headers: list[tuple[str, str | None]],
+        file_handle: BufferedIOBase | None,
+    ) -> Response:
+        headers: list[tuple[str, str | None]] = []
         size: int | None = None
         for item in base_headers:
             if item[0] == "Content-Length":
-                size = int(item[1])
+                if item[1] is not None:
+                    size = int(item[1])
             else:
                 headers.append(item)
         if size is None:
@@ -172,13 +193,19 @@ class StaticFile:
         ))
         return Response(HTTPStatus.PARTIAL_CONTENT, headers, file_handle)
 
-    async def aget_range_response(self, range_header, base_headers, file_handle):
+    async def aget_range_response(
+        self,
+        range_header: str,
+        base_headers: list[tuple[str, str | None]],
+        file_handle: AsyncFile | None,
+    ) -> Response:
         """Variant of `get_range_response` that works with async file objects."""
-        headers = []
+        headers: list[tuple[str, str | None]] = []
         size: int | None = None
         for item in base_headers:
             if item[0] == "Content-Length":
-                size = int(item[1])
+                if item[1] is not None:
+                    size = int(item[1])
             else:
                 headers.append(item)
         if size is None:
@@ -187,15 +214,16 @@ class StaticFile:
         start, end = self.get_byte_range(range_header, size)
         if start > end:
             return await self.aget_range_not_satisfiable_response(file_handle, size)
+        sliced_file: AsyncSlicedFile | None = None
         if file_handle is not None:
-            file_handle = AsyncSlicedFile(file_handle, start, end)
+            sliced_file = AsyncSlicedFile(file_handle, start, end)
         headers.extend((
             ("Content-Range", f"bytes {start}-{end}/{size}"),
             ("Content-Length", str(end - start + 1)),
         ))
-        return Response(HTTPStatus.PARTIAL_CONTENT, headers, file_handle)
+        return Response(HTTPStatus.PARTIAL_CONTENT, headers, sliced_file)
 
-    def get_byte_range(self, range_header, size):
+    def get_byte_range(self, range_header: str, size: int) -> tuple[int, int]:
         start, end = self.parse_byte_range(range_header)
         if start < 0:
             start = max(start + size, 0)
@@ -203,7 +231,7 @@ class StaticFile:
         return start, end
 
     @staticmethod
-    def parse_byte_range(range_header):
+    def parse_byte_range(range_header: str) -> tuple[int, int | None]:
         units, _, range_spec = range_header.strip().partition("=")
         if units != "bytes":
             raise ValueError
@@ -221,7 +249,7 @@ class StaticFile:
         return start, end
 
     @staticmethod
-    def get_range_not_satisfiable_response(file_handle, size):
+    def get_range_not_satisfiable_response(file_handle: BufferedIOBase | None, size: int) -> Response:
         if file_handle is not None:
             file_handle.close()
         return Response(
@@ -231,7 +259,7 @@ class StaticFile:
         )
 
     @staticmethod
-    async def aget_range_not_satisfiable_response(file_handle, size):
+    async def aget_range_not_satisfiable_response(file_handle: AsyncFile | None, size: int) -> Response:
         """Variant of `get_range_not_satisfiable_response` that works with
         async file objects. Async file handles do not need to be closed, since they
         are only opened via context managers while being dispatched."""
@@ -242,9 +270,13 @@ class StaticFile:
         )
 
     @staticmethod
-    def get_file_stats(path, encodings, stat_cache):
+    def get_file_stats(
+        path: str,
+        encodings: Mapping[str, str] | None,
+        stat_cache: Mapping[str, os.stat_result] | None,
+    ) -> dict[str | None, FileEntry]:
         # Primary file has an encoding of None
-        files = {None: FileEntry(path, stat_cache)}
+        files: dict[str | None, FileEntry] = {None: FileEntry(path, stat_cache)}
         if encodings:
             for encoding, alt_path in encodings.items():
                 try:
@@ -254,7 +286,7 @@ class StaticFile:
         return files
 
     @staticmethod
-    def get_headers(headers_list, files):
+    def get_headers(headers_list: list[tuple[str, str]], files: Mapping[str | None, FileEntry]) -> Headers:
         headers = Headers(headers_list)
         main_file = files[None]
         if len(files) > 1:
@@ -273,12 +305,15 @@ class StaticFile:
         return headers
 
     @staticmethod
-    def get_not_modified_response(headers):
+    def get_not_modified_response(headers: Headers) -> Response:
         not_modified_headers = [(key, headers[key]) for key in NOT_MODIFIED_HEADERS if key in headers]
         return Response(status=HTTPStatus.NOT_MODIFIED, headers=not_modified_headers, file=None)
 
     @staticmethod
-    def get_alternatives(base_headers, files):
+    def get_alternatives(
+        base_headers: Headers,
+        files: Mapping[str | None, FileEntry],
+    ) -> list[tuple[re.Pattern[str], str, list[tuple[str, str | None]]]]:
         # Sort by size so that the smallest compressed alternative matches first
         alternatives = []
         files_by_size = sorted(files.items(), key=lambda i: i[1].size)
@@ -293,7 +328,7 @@ class StaticFile:
             alternatives.append((encoding_re, file_entry.path, headers.items()))
         return alternatives
 
-    def is_not_modified(self, request_headers):
+    def is_not_modified(self, request_headers: Mapping[str, str]) -> bool:
         previous_etag = request_headers.get("HTTP_IF_NONE_MATCH")
         if previous_etag is not None:
             return previous_etag == self.etag
@@ -308,7 +343,7 @@ class StaticFile:
             return last_requested_ts >= self.last_modified
         return False
 
-    def get_path_and_headers(self, request_headers):
+    def get_path_and_headers(self, request_headers: Mapping[str, str]) -> tuple[str, list[tuple[str, str | None]]]:
         accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")
         if accept_encoding == "*":
             accept_encoding = ""
@@ -330,22 +365,22 @@ class StaticFile:
 class Redirect:
     location = "Location"
 
-    def __init__(self, location, headers=None):
-        headers = list(headers.items()) if headers else []
-        headers.append((self.location, quote(location.encode("utf8"))))
-        self.response = Response(HTTPStatus.FOUND, headers, None)
+    def __init__(self, location: str, headers: Mapping[str, str] | None = None) -> None:
+        response_headers: list[tuple[str, str | None]] = list(headers.items()) if headers else []
+        response_headers.append((self.location, quote(location.encode("utf8"))))
+        self.response = Response(HTTPStatus.FOUND, response_headers, None)
 
-    def get_response(self, method, request_headers):
+    def get_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
         query_string = request_headers.get("QUERY_STRING")
         if query_string:
             headers = list(self.response.headers)
             i, value = next((i, value) for (i, (name, value)) in enumerate(headers) if name == self.location)
-            value = f"{value}?{query_string}"
+            value = f"{value or ''}?{query_string}"
             headers[i] = (self.location, value)
             return Response(self.response.status, headers, None)
         return self.response
 
-    async def aget_response(self, method, request_headers):
+    async def aget_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
         return self.get_response(method, request_headers)
 
 
@@ -364,7 +399,7 @@ class IsDirectoryError(MissingFileError):
 class FileEntry:
     __slots__ = ("mtime", "path", "size")
 
-    def __init__(self, path, stat_cache=None):
+    def __init__(self, path: str, stat_cache: Mapping[str, os.stat_result] | None = None) -> None:
         self.path = path
         stat_function = os.stat if stat_cache is None else stat_cache.__getitem__
         stat_ = self.stat_regular_file(path, stat_function)
@@ -372,7 +407,7 @@ class FileEntry:
         self.mtime = stat_.st_mtime
 
     @staticmethod
-    def stat_regular_file(path, stat_function):
+    def stat_regular_file(path: str, stat_function: Callable[[str], os.stat_result]) -> os.stat_result:
         """
         Wrap `stat_function` to raise appropriate errors if `path` is not a
         regular file

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -9,7 +9,7 @@ from email.utils import formatdate, parsedate
 from http import HTTPStatus
 from io import BufferedIOBase
 from time import mktime
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING
 from urllib.parse import quote
 from wsgiref.headers import Headers
 
@@ -107,7 +107,7 @@ class AsyncSlicedFile:
     async def close(self) -> None:
         await self.fileobj.close()
 
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self) -> AsyncSlicedFile:  # noqa: PYI034
         return self
 
     async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:

--- a/src/servestatic/runserver_nostatic/__init__.py
+++ b/src/servestatic/runserver_nostatic/__init__.py
@@ -1,0 +1,1 @@
+"""This module is deprecated in favor of the main `servestatic` app. It is retained for backward compatibility with legacy WhiteNoise projects."""

--- a/src/servestatic/runserver_nostatic/apps.py
+++ b/src/servestatic/runserver_nostatic/apps.py
@@ -11,7 +11,7 @@ class ServeStaticRunserverNoStaticAliasConfig(ServeStaticConfig):
     name = "servestatic.runserver_nostatic"
     label = "servestatic_runserver_nostatic"
 
-    def ready(self):
+    def ready(self) -> None:
         super().ready()
         warn(
             "The 'servestatic.runserver_nostatic' app is deprecated. Use 'servestatic' instead.",

--- a/src/servestatic/storage.py
+++ b/src/servestatic/storage.py
@@ -26,10 +26,13 @@ _PostProcessT = Iterator[tuple[str, str | None, bool | Exception]]
 def get_compressor_kwargs(*, quiet: bool) -> dict[str, Any]:
     return {
         "extensions": getattr(settings, "SERVESTATIC_SKIP_COMPRESS_EXTENSIONS", None),
+        "use_gzip": getattr(settings, "SERVESTATIC_USE_GZIP", True),
+        "use_brotli": getattr(settings, "SERVESTATIC_USE_BROTLI", True),
         "use_zstd": getattr(settings, "SERVESTATIC_USE_ZSTD", True),
         "zstd_dict": getattr(settings, "SERVESTATIC_ZSTD_DICTIONARY", None),
         "zstd_dict_is_raw": getattr(settings, "SERVESTATIC_ZSTD_DICTIONARY_IS_RAW", False),
         "zstd_level": getattr(settings, "SERVESTATIC_ZSTD_LEVEL", None),
+        "minify": getattr(settings, "SERVESTATIC_MINIFY", False),
         "quiet": quiet,
     }
 

--- a/src/servestatic/storage.py
+++ b/src/servestatic/storage.py
@@ -29,10 +29,10 @@ def get_compressor_kwargs(*, quiet: bool) -> dict[str, Any]:
         "use_gzip": getattr(settings, "SERVESTATIC_USE_GZIP", True),
         "use_brotli": getattr(settings, "SERVESTATIC_USE_BROTLI", True),
         "use_zstd": getattr(settings, "SERVESTATIC_USE_ZSTD", True),
+        "minify": getattr(settings, "SERVESTATIC_MINIFY", False),
         "zstd_dict": getattr(settings, "SERVESTATIC_ZSTD_DICTIONARY", None),
         "zstd_dict_is_raw": getattr(settings, "SERVESTATIC_ZSTD_DICTIONARY_IS_RAW", False),
         "zstd_level": getattr(settings, "SERVESTATIC_ZSTD_LEVEL", None),
-        "minify": getattr(settings, "SERVESTATIC_MINIFY", False),
         "quiet": quiet,
     }
 

--- a/src/servestatic/storage.py
+++ b/src/servestatic/storage.py
@@ -20,7 +20,7 @@ from django.core.files.base import ContentFile
 from servestatic.compress import Compressor
 from servestatic.utils import stat_files
 
-_PostProcessT = Iterator[tuple[str, str, bool] | tuple[str, None, RuntimeError]]
+_PostProcessT = Iterator[tuple[str, str | None, bool | Exception]]
 
 
 def get_compressor_kwargs(*, quiet: bool) -> dict[str, Any]:
@@ -76,14 +76,14 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
     those without the hash in their name)
     """
 
-    _new_files = None
+    _new_files: set[str] | None = None
     compressor: Compressor | None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.manifest_strict = getattr(settings, "SERVESTATIC_MANIFEST_STRICT", True)
         super().__init__(*args, **kwargs)
 
-    def post_process(self, *args, **kwargs):  # pyright: ignore [reportIncompatibleMethodOverride]
+    def post_process(self, *args: Any, **kwargs: Any) -> _PostProcessT:  # pyright: ignore [reportIncompatibleMethodOverride]
         files = super().post_process(*args, **kwargs)
 
         if not kwargs.get("dry_run"):
@@ -97,7 +97,7 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
 
         self.add_stats_to_manifest()
 
-    def add_stats_to_manifest(self):
+    def add_stats_to_manifest(self) -> None:
         """Adds additional `stats` field to Django's manifest file."""
         current = self.read_manifest()
         current = json.loads(current) if current else {}
@@ -110,7 +110,7 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
         manifest_storage.delete(self.manifest_name)
         manifest_storage._save(self.manifest_name, ContentFile(new))  # pyright: ignore [reportAttributeAccessIssue]
 
-    def stat_static_root(self):
+    def stat_static_root(self) -> dict[str, os.stat_result]:
         """Stats all the files within the static root folder."""
         static_root = getattr(settings, "STATIC_ROOT", None)
         if static_root is None:
@@ -127,7 +127,7 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
         # Remove the static root folder from the path
         return {path[len(static_root) + 1 :]: stat for path, stat in stats.items()}
 
-    def load_manifest_stats(self):
+    def load_manifest_stats(self) -> dict[str, list[int] | tuple[int, ...]]:
         """Derivative of Django's `load_manifest` but for the `stats` field."""
         content = self.read_manifest()
         if content is None:
@@ -138,7 +138,7 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
         msg = f"Couldn't load stats from manifest '{self.manifest_name}'"
         raise ValueError(msg)
 
-    def post_process_with_compression(self, files):
+    def post_process_with_compression(self, files: _PostProcessT) -> _PostProcessT:
         # Files may get hashed multiple times, we want to keep track of all the
         # intermediate files generated during the process and which of these
         # are the final names used for each file. As not every intermediate
@@ -164,23 +164,23 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
         for name, compressed_name in self.compress_files(files_to_compress):
             yield name, compressed_name, True
 
-    def hashed_name(self, *args, **kwargs):
+    def hashed_name(self, *args: Any, **kwargs: Any) -> str:
         name = super().hashed_name(*args, **kwargs)
         if self._new_files is not None:
             self._new_files.add(self.clean_name(name))
         return name
 
-    def start_tracking_new_files(self, new_files):
+    def start_tracking_new_files(self, new_files: set[str]) -> None:
         self._new_files = new_files
 
-    def stop_tracking_new_files(self):
+    def stop_tracking_new_files(self) -> None:
         self._new_files = None
 
     @property
-    def keep_only_hashed_files(self):
+    def keep_only_hashed_files(self) -> bool:
         return getattr(settings, "SERVESTATIC_KEEP_ONLY_HASHED_FILES", False)
 
-    def delete_files(self, files_to_delete):
+    def delete_files(self, files_to_delete: set[str]) -> None:
         for name in files_to_delete:
             try:
                 os.unlink(self.path(name))
@@ -188,10 +188,10 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
                 if e.errno != errno.ENOENT:
                     raise
 
-    def create_compressor(self, **kwargs):  # noqa: PLR6301
+    def create_compressor(self, **kwargs: Any) -> Compressor:  # noqa: PLR6301
         return Compressor(**kwargs)
 
-    def compress_files(self, paths):
+    def compress_files(self, paths: set[str]) -> Iterator[tuple[str, str]]:
         self.compressor = compressor = self.create_compressor(**get_compressor_kwargs(quiet=True))
 
         def _compress_path(path: str) -> list[tuple[str, str]]:
@@ -208,7 +208,7 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
             for future in as_completed(futures):
                 yield from future.result()
 
-    def make_helpful_exception(self, exception, name):
+    def make_helpful_exception(self, exception: Exception, name: str) -> Exception:
         """
         If a CSS file contains references to images, fonts etc that can't be found
         then Django's `post_process` blows up with a not particularly helpful

--- a/src/servestatic/utils.py
+++ b/src/servestatic/utils.py
@@ -6,36 +6,39 @@ import contextlib
 import functools
 import os
 from concurrent.futures import ThreadPoolExecutor
-from io import IOBase
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, Self, TypeVar, cast
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import AsyncIterable, Callable, Iterable
+    from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator
     from io import IOBase
+    from os import PathLike
 
     from servestatic.responders import AsyncSlicedFile
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 # This is the same size as wsgiref.FileWrapper
 ASGI_BLOCK_SIZE = 8192
 
 
-def get_block_size():
+def get_block_size() -> int:
     return ASGI_BLOCK_SIZE
 
 
 # Follow Django in treating URLs as UTF-8 encoded (which requires undoing the
 # implicit ISO-8859-1 decoding applied in Python 3). Strictly speaking, URLs
 # should only be ASCII anyway, but UTF-8 can be found in the wild.
-def decode_path_info(path_info):
+def decode_path_info(path_info: str) -> str:
     return path_info.encode("iso-8859-1", "replace").decode("utf-8", "replace")
 
 
-def ensure_leading_trailing_slash(path):
+def ensure_leading_trailing_slash(path: str | None) -> str:
     path = (path or "").strip("/")
     return f"/{path}/" if path else "/"
 
 
-def scantree(root):
+def scantree(root: str | PathLike[str]) -> Iterator[tuple[str, os.stat_result]]:
     """
     Recurse the given directory yielding (pathname, os.stat(pathname)) pairs
     """
@@ -46,7 +49,7 @@ def scantree(root):
             yield entry.path, entry.stat()
 
 
-def stat_files(paths: Iterable[str]) -> dict:
+def stat_files(paths: Iterable[str]) -> dict[str, os.stat_result]:
     """Stat a list of file paths via threads."""
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -64,10 +67,10 @@ class AsyncToSyncIterator:
     or may be closed unexpectedly.
     """
 
-    def __init__(self, iterator: AsyncIterable):
+    def __init__(self, iterator: AsyncIterable[bytes]) -> None:
         self.iterator = iterator
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[bytes]:
         # Create a dedicated event loop to run the async iterator on.
         loop = asyncio.new_event_loop()
         thread_executor = concurrent.futures.ThreadPoolExecutor(
@@ -85,13 +88,15 @@ class AsyncToSyncIterator:
             thread_executor.shutdown(wait=True)
 
 
-def open_lazy(f):
+def open_lazy(
+    f: Callable[Concatenate[AsyncFile, P], Awaitable[T]],
+) -> Callable[Concatenate[AsyncFile, P], Awaitable[T]]:
     """Decorator that ensures the file is open before calling a function.
     This can be turned into a @staticmethod on `AsyncFile` once we drop Python 3.9 compatibility.
     """
 
     @functools.wraps(f)
-    async def wrapper(self: AsyncFile, *args, **kwargs):
+    async def wrapper(self: AsyncFile, *args: P.args, **kwargs: P.kwargs) -> T:
         if self.closed:
             msg = "I/O operation on closed file."
             raise ValueError(msg)
@@ -110,7 +115,7 @@ class AsyncFile:
 
     def __init__(
         self,
-        file_path,
+        file_path: str | PathLike[str],
         mode: str = "r",
         buffering: int = -1,
         encoding: str | None = None,
@@ -118,8 +123,8 @@ class AsyncFile:
         newline: str | None = None,
         closefd: bool = True,
         opener: Callable[[str, int], int] | None = None,
-    ):
-        self.open_args = (
+    ) -> None:
+        self.open_args: tuple[object, ...] = (
             file_path,
             mode,
             buffering,
@@ -135,7 +140,7 @@ class AsyncFile:
         self.closed = False
         self._executor_shutdown = False
 
-    def _shutdown_executor(self):
+    def _shutdown_executor(self) -> None:
         if self._executor_shutdown:
             return
         try:
@@ -144,61 +149,61 @@ class AsyncFile:
             return
         self._executor_shutdown = True
 
-    async def _execute(self, func, *args):
+    async def _execute(self, func: Callable[..., T], *args: object) -> T:
         """Run a function in a dedicated thread (specific to each AsyncFile instance)."""
         if self.loop is None:
             self.loop = asyncio.get_running_loop()
         return await self.loop.run_in_executor(self.executor, func, *args)
 
-    async def close(self):
+    async def close(self) -> None:
         self.closed = True
         if self.file_obj is not None:
             await self._execute(self.file_obj.close)
         self._shutdown_executor()
 
     @open_lazy
-    async def read(self, size=-1):
+    async def read(self, size: int = -1) -> bytes:
         if self.file_obj is None:
             msg = "File object was not opened"
             raise RuntimeError(msg)
         return await self._execute(self.file_obj.read, size)
 
     @open_lazy
-    async def seek(self, offset, whence=0):
+    async def seek(self, offset: int, whence: int = 0) -> int:
         if self.file_obj is None:
             msg = "File object was not opened"
             raise RuntimeError(msg)
         return await self._execute(self.file_obj.seek, offset, whence)
 
     @open_lazy
-    async def __aenter__(self):
+    async def __aenter__(self) -> Self:
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         await self.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self._shutdown_executor()
 
 
 class EmptyAsyncIterator:
     """Placeholder async iterator for responses that have no content."""
 
-    def __aiter__(self):
+    def __aiter__(self) -> EmptyAsyncIterator:
         return self
 
-    async def __anext__(self):
+    async def __anext__(self) -> bytes:
         raise StopAsyncIteration
 
 
 class AsyncFileIterator:
     """Async iterator that yields chunks of data from the provided async file."""
 
-    def __init__(self, async_file: AsyncFile | AsyncSlicedFile):
+    def __init__(self, async_file: AsyncFile | AsyncSlicedFile) -> None:
         self.async_file = async_file
         self.block_size = get_block_size()
 
-    async def __aiter__(self):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
         async with self.async_file as file:
             while True:
                 chunk = await file.read(self.block_size)

--- a/src/servestatic/utils.py
+++ b/src/servestatic/utils.py
@@ -6,7 +6,7 @@ import contextlib
 import functools
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Concatenate, ParamSpec, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, TypeVar, cast
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator
@@ -176,7 +176,7 @@ class AsyncFile:
         return await self._execute(self.file_obj.seek, offset, whence)
 
     @open_lazy
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self) -> AsyncFile:  # noqa: PYI034
         return self
 
     async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:

--- a/src/servestatic/wsgi.py
+++ b/src/servestatic/wsgi.py
@@ -7,13 +7,16 @@ from servestatic.base import ServeStaticBase
 from servestatic.utils import decode_path_info
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Iterable
+    from wsgiref.types import StartResponse, WSGIApplication, WSGIEnvironment
+
+    from servestatic.responders import Redirect, StaticFile
 
 
 class ServeStatic(ServeStaticBase):
-    application: Callable
+    application: WSGIApplication
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
         # Determine if the request is for a static file
         path = decode_path_info(environ.get("PATH_INFO", ""))
         static_file = self.find_file(path) if self.autorefresh else self.files.get(path)
@@ -25,7 +28,7 @@ class ServeStatic(ServeStaticBase):
         # Could not find a static file. Serve the default application instead.
         return self.application(environ, start_response)
 
-    def initialize(self):
+    def initialize(self) -> None:
         """Ensure the WSGI application is initialized."""
         # If no application is provided, default to a "404 Not Found" app
         self.application = self.application or NotFoundWSGI()
@@ -34,13 +37,14 @@ class ServeStatic(ServeStaticBase):
 class FileServerWSGI:
     """Primitive WSGI application that streams a StaticFile over HTTP in chunks."""
 
-    def __init__(self, static_file):
+    def __init__(self, static_file: StaticFile | Redirect) -> None:
         self.static_file = static_file
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
         response = self.static_file.get_response(environ["REQUEST_METHOD"], environ)
         status_line = f"{response.status} {response.status.phrase}"
-        start_response(status_line, list(response.headers))
+        headers = [(key, value) for key, value in response.headers if value is not None]
+        start_response(status_line, headers)
         if response.file is not None:
             # Try to use a more efficient transmit method, if available
             file_wrapper = environ.get("wsgi.file_wrapper", FileWrapper)
@@ -51,7 +55,7 @@ class FileServerWSGI:
 class NotFoundWSGI:
     """A WSGI application that returns a 404 Not Found response."""
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
         status = "404 Not Found"
         headers = [("Content-Type", "text/plain; charset=utf-8")]
         start_response(status, headers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 import servestatic.cli as servestatic_cli
+import servestatic.compress as compress_module
 from servestatic.cli import main
 
 
@@ -446,3 +447,47 @@ def test_cli_passes_zstd_options_to_compressor(tmp_path, monkeypatch):
     assert captured_args["zstd_dict"] == str(dict_file)
     assert captured_args["zstd_dict_is_raw"] is True
     assert captured_args["zstd_level"] == 9
+
+
+def test_cli_warns_when_brotli_requested_but_unavailable(tmp_path, monkeypatch, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "test.txt").write_text("content\n" * 1000)
+    dest = tmp_path / "dest"
+
+    monkeypatch.setattr(compress_module, "brotli", None)
+
+    main(["--compress", "--no-gzip", "--no-zstd", str(src), str(dest)])
+
+    captured = capsys.readouterr()
+    assert "Warning: Brotli compression requested but brotli is not installed" in captured.out
+
+
+def test_cli_warns_when_zstd_requested_but_unavailable(tmp_path, monkeypatch, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "test.txt").write_text("content\n" * 1000)
+    dest = tmp_path / "dest"
+
+    monkeypatch.setattr(compress_module, "zstd", None)
+
+    main(["--compress", "--no-gzip", "--no-brotli", str(src), str(dest)])
+
+    captured = capsys.readouterr()
+    assert "Warning: Zstandard compression requested but compression.zstd is unavailable" in captured.out
+
+
+def test_cli_errors_when_zstd_dictionary_requested_but_unavailable(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "test.txt").write_text("content\n" * 1000)
+    dest = tmp_path / "dest"
+    dict_file = tmp_path / "dict.bin"
+    dict_file.write_bytes(b"dict")
+
+    monkeypatch.setattr(compress_module, "zstd", None)
+
+    with pytest.raises(
+        RuntimeError, match=r"Zstandard dictionary support requires Python 3.14\+ with compression\.zstd available"
+    ):
+        main(["--compress", "--zstd-dict", str(dict_file), str(src), str(dest)])

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -68,8 +68,9 @@ def test_with_falsey_extensions():
 
 
 def test_custom_log():
-    compressor = Compressor(log="test")
-    assert compressor.log == "test"
+    new_logger = mock.Mock()
+    compressor = Compressor(log=new_logger)
+    assert compressor.log == new_logger
 
 
 def test_compress():

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -93,6 +93,73 @@ def test_main_error(files_dir):
     assert excinfo.value.args == ("woops",)
 
 
+def test_compress_minify_raises_when_dependency_missing(monkeypatch):
+    monkeypatch.setattr(compress_module, "rcssmin", None)
+    monkeypatch.setattr(compress_module, "rjsmin", None)
+    with pytest.raises(ImportError, match=r"Minification requested but rcssmin or rjsmin is not installed\."):
+        Compressor(minify=True)
+
+
+def test_compress_minify_reduces_size(tmp_path):
+    pytest.importorskip("rcssmin")
+    pytest.importorskip("rjsmin")
+
+    css_content = b"body { color: red; } /* comment */\n" * 100
+    js_content = b"function foo() { \n    console.log('hi'); \n} // comment \n" * 100
+
+    css_path = tmp_path / "test.css"
+    css_path.write_bytes(css_content)
+    js_path = tmp_path / "test.js"
+    js_path.write_bytes(js_content)
+    other_path = tmp_path / "test.txt"
+    other_path.write_bytes(css_content)
+
+    compressor_no_minify = Compressor(minify=False, use_gzip=True, use_brotli=False, use_zstd=False, quiet=True)
+    compressor_minify = Compressor(minify=True, use_gzip=True, use_brotli=False, use_zstd=False, quiet=True)
+
+    compressor_no_minify.compress(css_path)
+    css_gz_path = tmp_path / "test.css.gz"
+    size_css_no_minify = css_gz_path.stat().st_size
+    css_gz_path.unlink()
+
+    compressor_minify.compress(css_path)
+    size_css_minify = css_gz_path.stat().st_size
+
+    assert size_css_minify < size_css_no_minify
+
+    compressor_no_minify.compress(js_path)
+    js_gz_path = tmp_path / "test.js.gz"
+    size_js_no_minify = js_gz_path.stat().st_size
+    js_gz_path.unlink()
+
+    compressor_minify.compress(js_path)
+    size_js_minify = js_gz_path.stat().st_size
+
+    assert size_js_minify < size_js_no_minify
+
+    compressor_no_minify.compress(other_path)
+    other_gz_path = tmp_path / "test.txt.gz"
+    size_other_no_minify = other_gz_path.stat().st_size
+    other_gz_path.unlink()
+
+    compressor_minify.compress(other_path)
+    size_other_minify = other_gz_path.stat().st_size
+
+    assert size_other_minify == size_other_no_minify
+
+
+def test_compress_minify_ignores_decode_error(tmp_path):
+    pytest.importorskip("rcssmin")
+    pytest.importorskip("rjsmin")
+
+    css_path = tmp_path / "test.css"
+    # An invalid utf-8 sequence shouldn't crash the compressor
+    css_path.write_bytes(b"\xff\xfe" * 100)
+
+    compressor = Compressor(minify=True, use_gzip=True, use_brotli=False, use_zstd=False, quiet=True)
+    compressor.compress(css_path)
+
+
 def test_compress_brotli_raises_when_dependency_missing(monkeypatch):
     monkeypatch.setattr(compress_module, "brotli", None)
     with pytest.raises(RuntimeError, match="Brotli is not installed"):

--- a/tests/test_django_servestatic.py
+++ b/tests/test_django_servestatic.py
@@ -473,6 +473,18 @@ def test_django_check_reports_immutable_file_test_invalid_type():
     assert len(errors) == 1
 
 
+@override_settings(INSTALLED_APPS=["servestatic.runserver_nostatic", "django.contrib.staticfiles"])
+def test_django_check_warns_for_deprecated_servestatic_runserver_nostatic_app():
+    warnings = [check_message for check_message in run_checks() if check_message.id == "servestatic.W001"]
+    assert len(warnings) == 1
+
+
+@override_settings(INSTALLED_APPS=["servestatic", "django.contrib.staticfiles"])
+def test_django_check_does_not_warn_for_canonical_servestatic_app():
+    warnings = [check_message for check_message in run_checks() if check_message.id == "servestatic.W001"]
+    assert not warnings
+
+
 def test_middleware_warns_when_servestatic_app_is_missing(async_middleware_response):
     class Settings:
         DEBUG = True

--- a/tests/test_django_servestatic.py
+++ b/tests/test_django_servestatic.py
@@ -387,6 +387,8 @@ def test_django_check_accepts_correct_gzip_middleware_order():
         ({"SERVESTATIC_CHARSET": ""}, "servestatic.E017"),
         ({"SERVESTATIC_ALLOW_ALL_ORIGINS": "yes"}, "servestatic.E018"),
         ({"SERVESTATIC_SKIP_COMPRESS_EXTENSIONS": "jpg,png"}, "servestatic.E019"),
+        ({"SERVESTATIC_USE_GZIP": "yes"}, "servestatic.E032"),
+        ({"SERVESTATIC_USE_BROTLI": "yes"}, "servestatic.E033"),
         ({"SERVESTATIC_USE_ZSTD": "yes"}, "servestatic.E020"),
         ({"SERVESTATIC_ZSTD_DICTIONARY": 123}, "servestatic.E021"),
         ({"SERVESTATIC_ZSTD_DICTIONARY_IS_RAW": "yes"}, "servestatic.E022"),
@@ -397,6 +399,7 @@ def test_django_check_accepts_correct_gzip_middleware_order():
         ({"SERVESTATIC_KEEP_ONLY_HASHED_FILES": "yes"}, "servestatic.E027"),
         ({"SERVESTATIC_MANIFEST_STRICT": "yes"}, "servestatic.E028"),
         ({"SERVESTATIC_ALLOW_UNSAFE_SYMLINKS": "yes"}, "servestatic.E029"),
+        ({"SERVESTATIC_MINIFY": "yes"}, "servestatic.E031"),
     ],
 )
 def test_django_check_reports_invalid_setting_types(overrides, error_id):

--- a/tests/test_django_servestatic.py
+++ b/tests/test_django_servestatic.py
@@ -560,13 +560,12 @@ def test_middleware_blocks_symlink_escape_by_default(async_middleware_response):
         class Settings:
             DEBUG = False
             INSTALLED_APPS = ["servestatic", "django.contrib.staticfiles"]
-            SERVESTATIC_ROOT = static_dir
             SERVESTATIC_AUTOREFRESH = True
             SERVESTATIC_USE_MANIFEST = False
             SERVESTATIC_USE_FINDERS = False
             SERVESTATIC_STATIC_PREFIX = "/"
             STATIC_URL = "/"
-            STATIC_ROOT = None
+            STATIC_ROOT = static_dir
 
         middleware = ServeStaticMiddleware(get_response=async_middleware_response, settings=Settings)
         response = asyncio.run(middleware(build_dummy_request("/link-outside.txt")))
@@ -582,14 +581,13 @@ def test_middleware_can_enable_symlink_escape(async_middleware_response):
         class Settings:
             DEBUG = False
             INSTALLED_APPS = ["servestatic", "django.contrib.staticfiles"]
-            SERVESTATIC_ROOT = static_dir
             SERVESTATIC_AUTOREFRESH = True
             SERVESTATIC_ALLOW_UNSAFE_SYMLINKS = True
             SERVESTATIC_USE_MANIFEST = False
             SERVESTATIC_USE_FINDERS = False
             SERVESTATIC_STATIC_PREFIX = "/"
             STATIC_URL = "/"
-            STATIC_ROOT = None
+            STATIC_ROOT = static_dir
 
         middleware = ServeStaticMiddleware(get_response=async_middleware_response, settings=Settings)
         response = asyncio.run(middleware(build_dummy_request("/link-outside.txt")))
@@ -607,13 +605,12 @@ def test_middleware_blocks_finder_symlink_escape_in_autorefresh(monkeypatch, asy
         class Settings:
             DEBUG = False
             INSTALLED_APPS = ["servestatic", "django.contrib.staticfiles"]
-            SERVESTATIC_ROOT = static_dir
             SERVESTATIC_AUTOREFRESH = True
             SERVESTATIC_USE_MANIFEST = False
             SERVESTATIC_USE_FINDERS = False
             SERVESTATIC_STATIC_PREFIX = "/"
             STATIC_URL = "/"
-            STATIC_ROOT = None
+            STATIC_ROOT = static_dir
 
         middleware = ServeStaticMiddleware(get_response=async_middleware_response, settings=Settings)
         middleware.use_finders = True
@@ -1037,3 +1034,72 @@ def test_manifest_with_keep_only_hashed_2():
         finally:
             static_root: Path = settings.STATIC_ROOT
             shutil.rmtree(static_root, ignore_errors=True)
+
+
+@pytest.mark.skipif(django.VERSION >= (5, 0), reason="Django <5.0 only")
+@pytest.mark.usefixtures("static_files")
+def test_django_compressor_files_served_when_use_manifest_true(static_files):
+    with override_settings(
+        SERVESTATIC_USE_MANIFEST=True, SERVESTATIC_USE_STATIC_ROOT=True, SERVESTATIC_KEEP_ONLY_HASHED_FILES=False
+    ):
+        try:
+            # Collect static files
+            reset_lazy_object(storage.staticfiles_storage)
+            call_command("collectstatic", verbosity=0, interactive=False)
+
+            # "django-compressor" runs here: write a new file directly into STATIC_ROOT
+            compressor_path = os.path.join(storage.staticfiles_storage.location, "CACHE", "css", "output.css")
+            os.makedirs(os.path.dirname(compressor_path), exist_ok=True)
+            with open(compressor_path, "w", encoding="utf-8") as f:
+                f.write("body { color: blue; }")
+
+            original_url = "/static/CACHE/css/output.css"
+
+            # Check if SERVESTATIC_USE_STATIC_ROOT allows the new CACHE file
+            scope = AsgiHttpScopeEmulator({"path": original_url, "headers": []})
+            receive = AsgiReceiveEmulator()
+            send = AsgiSendEmulator()
+            asyncio.run(AsgiAppServer(get_asgi_application())(scope, receive, send))
+            assert send.status == 200
+
+        finally:
+            static_root: Path = settings.STATIC_ROOT
+            shutil.rmtree(static_root, ignore_errors=True)
+            reset_lazy_object(storage.staticfiles_storage)
+
+
+@pytest.mark.skipif(django.VERSION < (5, 0), reason="Django >=5.0 only")
+@pytest.mark.usefixtures("static_files")
+def test_django_compressor_files_served_when_use_manifest_true_2(static_files):
+    with override_settings(
+        SERVESTATIC_USE_MANIFEST=True, SERVESTATIC_USE_STATIC_ROOT=True, SERVESTATIC_KEEP_ONLY_HASHED_FILES=False
+    ):
+        try:
+            # Collect static files
+            reset_lazy_object(storage.staticfiles_storage)
+            call_command("collectstatic", verbosity=0, interactive=False)
+
+            # "django-compressor" runs here: write a new file directly into STATIC_ROOT
+            compressor_path = os.path.join(storage.staticfiles_storage.location, "CACHE", "css", "output.css")
+            os.makedirs(os.path.dirname(compressor_path), exist_ok=True)
+            with open(compressor_path, "w", encoding="utf-8") as f:
+                f.write("body { color: blue; }")
+
+            original_url = "/static/CACHE/css/output.css"
+
+            # Check if SERVESTATIC_USE_STATIC_ROOT allows the new CACHE file
+            async def executor():
+                scope = AsgiHttpScopeEmulator({"path": original_url, "headers": []})
+                communicator = ApplicationCommunicator(get_asgi_application(), scope)
+                await communicator.send_input(scope)
+                response_start = await communicator.receive_output()
+                response_body = await communicator.receive_output()
+                return response_start | response_body
+
+            response = asyncio.run(executor())
+            assert response["status"] == 200
+
+        finally:
+            static_root: Path = settings.STATIC_ROOT
+            shutil.rmtree(static_root, ignore_errors=True)
+            reset_lazy_object(storage.staticfiles_storage)

--- a/tests/test_django_servestatic.py
+++ b/tests/test_django_servestatic.py
@@ -1103,3 +1103,54 @@ def test_django_compressor_files_served_when_use_manifest_true_2(static_files):
             static_root: Path = settings.STATIC_ROOT
             shutil.rmtree(static_root, ignore_errors=True)
             reset_lazy_object(storage.staticfiles_storage)
+
+
+def test_static_file_range_without_content_length():
+    import pytest
+
+    from servestatic.responders import StaticFile
+
+    sf = StaticFile.__new__(StaticFile)
+    with pytest.raises(ValueError, match="Content-Length header is required for range requests"):
+        sf.get_range_response("bytes=0-10", [("Content-Length", None)], None)
+
+
+def test_static_file_arange_without_content_length():
+    import asyncio
+
+    import pytest
+
+    from servestatic.responders import StaticFile
+
+    sf = StaticFile.__new__(StaticFile)
+    with pytest.raises(ValueError, match="Content-Length header is required for range requests"):
+        asyncio.run(sf.aget_range_response("bytes=0-10", [("Content-Length", None)], None))
+
+
+def test_aserve_with_none_header():
+    import asyncio
+
+    from django.http import HttpRequest
+
+    from servestatic.middleware import ServeStaticMiddleware
+    from servestatic.responders import Response
+
+    class FakeStaticFile:
+        async def aget_response(self, method, meta):
+            return Response(200, [("X-Test", None)], None)
+
+    request = HttpRequest()
+    request.method = "GET"
+    request.META = {}
+
+    response = asyncio.run(ServeStaticMiddleware.aserve(FakeStaticFile(), request))
+    assert "X-Test" not in response
+
+
+def test_get_static_url_value_error():
+    from unittest import mock
+
+    from servestatic.middleware import ServeStaticMiddleware
+
+    with mock.patch("servestatic.middleware.staticfiles_storage.url", side_effect=ValueError):
+        assert ServeStaticMiddleware.get_static_url("foo") is None

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -299,6 +299,20 @@ def test_overlong_trailing_ranges_return_entire_file(server, files):
     assert response.content == files.js_content
 
 
+def test_request_last_byte(server, files):
+    last_byte = len(files.js_content) - 1
+    response = server.get(files.js_url, headers={"Range": f"bytes={last_byte}-{last_byte}"})
+    assert response.status_code == 206
+    assert response.content == files.js_content[-1:]
+
+
+def test_request_last_byte_plus_one_is_out_of_range(server, files):
+    last_byte_plus_one = len(files.js_content)
+    response = server.get(files.js_url, headers={"Range": f"bytes={last_byte_plus_one}-{last_byte_plus_one}"})
+    assert response.status_code == 416
+    assert response.headers["Content-Range"] == f"bytes */{len(files.js_content)}"
+
+
 def test_out_of_range_error(server, files):
     response = server.get(files.js_url, headers={"Range": "bytes=10000-11000"})
     assert response.status_code == 416


### PR DESCRIPTION
## Description

- Fix #101 
- Add JavaScript and CSS minification support to the `servestatic` CLI command.
- Add JavaScript and CSS minification support to Django.
- Add type hints to all user APIs
- Add CLI warnings of zstd/brotli are missing
- Add warning for usage of legacy `servestatic.runserver_nostatic`
- Misc doc clean-up

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
