### PR TITLE
Remove upper bound on packaging dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the redundant `packaging` build dependency.
+
 ## [4.3.1] - 2026-06-06
 
 - Fix manifest file mangling during `collectstatic` dry run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling", "packaging<26"]
+requires = ["hatchling", "packaging"]
 
 [project]
 name = "servestatic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling", "packaging"]
+requires = ["hatchling"]
 
 [project]
 name = "servestatic"


### PR DESCRIPTION
## Description

Remove the <26 upper version constraint from the packaging dependency.

This constraint causes a conflict when integrating ServeStatic into Buildroot, which currently ships with packaging==26.2. According to @Archmonger, there is no known reason for retaining the upper bound.

## Testing

Successfully built ServeStatic with packaging==26.3 using commands `python -m build` and `hatch build`.