### PR TITLE
4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
+- No changes here, yet!
+
+## [4.3.2] - 2026-09-01
+
 ### Changed
 
 - Remove the redundant `packaging` build dependency.
@@ -181,7 +185,8 @@ Don't forget to remove deprecated code on each major release!
 
 - Forked from [`whitenoise`](https://github.com/evansd/whitenoise) to add ASGI support.
 
-[Unreleased]: https://github.com/Archmonger/ServeStatic/compare/4.3.1...HEAD
+[Unreleased]: https://github.com/Archmonger/ServeStatic/compare/4.3.2...HEAD
+[4.3.2]: https://github.com/Archmonger/ServeStatic/compare/4.3.1...4.3.2
 [4.3.1]: https://github.com/Archmonger/ServeStatic/compare/4.3.0...4.3.1
 [4.3.0]: https://github.com/Archmonger/ServeStatic/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/Archmonger/ServeStatic/compare/4.1.0...4.2.0

--- a/src/servestatic/__init__.py
+++ b/src/servestatic/__init__.py
@@ -3,6 +3,6 @@ from __future__ import annotations
 from servestatic.asgi import ServeStaticASGI
 from servestatic.wsgi import ServeStatic
 
-__version__ = "4.3.1"
+__version__ = "4.3.2"
 
 __all__ = ["ServeStatic", "ServeStaticASGI"]


### PR DESCRIPTION
## Summary

Release preparation for version `4.3.2`.

- Bump package version to `4.3.2` in `src/servestatic/__init__.py`.
- Create a `4.3.2` changelog section encompassing the current unreleased changes (removal of the redundant `packaging` build dependency).
- Update changelog URL/link references for the new release.
- Reset the `[Unreleased]` section to "No changes here, yet!".

Not merging — release PR only.