### PR TITLE
Parse Accept-Encoding instead of matching it as a substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Don't forget to remove deprecated code on each major release!
 
 ### Changed
 
+- Parse the `Accept-Encoding` header rather than matching it as a substring. A coding refused with `q=0`, such as `gzip;q=0`, is no longer served, and a coding is only offered when its name appears as a whole token.
 - Remove the redundant `packaging` build dependency.
 
 ## [4.3.1] - 2026-06-06

--- a/docs/src/dictionary.txt
+++ b/docs/src/dictionary.txt
@@ -44,3 +44,4 @@ symlinks
 minification
 minify
 uncached
+substring

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import errno
 import os
-import re
 import stat
 from email.utils import formatdate, parsedate
 from http import HTTPStatus
@@ -313,7 +312,7 @@ class StaticFile:
     def get_alternatives(
         base_headers: Headers,
         files: Mapping[str | None, FileEntry],
-    ) -> list[tuple[re.Pattern[str], str, list[tuple[str, str | None]]]]:
+    ) -> list[tuple[str | None, str, list[tuple[str, str | None]]]]:
         # Sort by size so that the smallest compressed alternative matches first
         alternatives = []
         files_by_size = sorted(files.items(), key=lambda i: i[1].size)
@@ -322,10 +321,7 @@ class StaticFile:
             headers["Content-Length"] = str(file_entry.size)
             if encoding:
                 headers["Content-Encoding"] = encoding
-                encoding_re = re.compile(rf"\b{encoding}\b")
-            else:
-                encoding_re = re.compile(r"")
-            alternatives.append((encoding_re, file_entry.path, headers.items()))
+            alternatives.append((encoding, file_entry.path, headers.items()))
         return alternatives
 
     def is_not_modified(self, request_headers: Mapping[str, str]) -> bool:
@@ -347,12 +343,14 @@ class StaticFile:
         accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")
         if accept_encoding == "*":
             accept_encoding = ""
+        accepted = parse_accept_encoding(accept_encoding)
         # These are sorted by size so first match is the best
         result = next(
             (
                 (path, headers)
-                for encoding_re, path, headers in self.alternatives
-                if encoding_re.search(accept_encoding)
+                for encoding, path, headers in self.alternatives
+                # An uncompressed file is always an acceptable fallback.
+                if not encoding or encoding in accepted
             ),
             None,
         )
@@ -360,6 +358,40 @@ class StaticFile:
             msg = "No matching file found from path."
             raise MissingFileError(msg)
         return result
+
+
+def parse_accept_encoding(header: str) -> set[str]:
+    """
+    Return the set of content codings the client is willing to accept.
+
+    The header is parsed as described in RFC 9110 section 12.5.3 rather than
+    matched as a substring, so that a coding the client has refused with
+    ``q=0`` is not offered to it, and a coding name is only recognised when it
+    appears as a whole token.
+    """
+    accepted: set[str] = set()
+    for entry in header.split(","):
+        coding, _, params = entry.partition(";")
+        coding = coding.strip().lower()
+        if not coding:
+            continue
+        quality = 1.0
+        for param in params.split(";"):
+            name, sep, value = param.partition("=")
+            if name.strip().lower() != "q":
+                continue
+            if not sep:
+                break
+            try:
+                quality = float(value.strip())
+            except ValueError:
+                # An unparseable qvalue makes the whole entry invalid; treat
+                # the coding as unacceptable rather than guess.
+                quality = 0.0
+            break
+        if quality > 0:
+            accepted.add(coding)
+    return accepted
 
 
 class Redirect:

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 from wsgiref.headers import Headers
 
-from servestatic.utils import AsyncFile
+from servestatic.utils import AsyncFile, parse_accept_encoding
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -358,40 +358,6 @@ class StaticFile:
             msg = "No matching file found from path."
             raise MissingFileError(msg)
         return result
-
-
-def parse_accept_encoding(header: str) -> set[str]:
-    """
-    Return the set of content codings the client is willing to accept.
-
-    The header is parsed as described in RFC 9110 section 12.5.3 rather than
-    matched as a substring, so that a coding the client has refused with
-    ``q=0`` is not offered to it, and a coding name is only recognised when it
-    appears as a whole token.
-    """
-    accepted: set[str] = set()
-    for entry in header.split(","):
-        coding, _, params = entry.partition(";")
-        coding = coding.strip().lower()
-        if not coding:
-            continue
-        quality = 1.0
-        for param in params.split(";"):
-            name, sep, value = param.partition("=")
-            if name.strip().lower() != "q":
-                continue
-            if not sep:
-                break
-            try:
-                quality = float(value.strip())
-            except ValueError:
-                # An unparseable qvalue makes the whole entry invalid; treat
-                # the coding as unacceptable rather than guess.
-                quality = 0.0
-            break
-        if quality > 0:
-            accepted.add(coding)
-    return accepted
 
 
 class Redirect:

--- a/src/servestatic/utils.py
+++ b/src/servestatic/utils.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import functools
+import math
 import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Concatenate, ParamSpec, TypeVar, cast
@@ -36,6 +37,45 @@ def decode_path_info(path_info: str) -> str:
 def ensure_leading_trailing_slash(path: str | None) -> str:
     path = (path or "").strip("/")
     return f"/{path}/" if path else "/"
+
+
+def parse_accept_encoding(header: str) -> set[str]:
+    """
+    Return the set of content codings the client is willing to accept.
+
+    The header is parsed as described in RFC 9110 section 12.5.3 rather than
+    matched as a substring, so that a coding the client has refused with
+    ``q=0`` is not offered to it, and a coding name is only recognised when it
+    appears as a whole token.
+    """
+    accepted: set[str] = set()
+    for entry in header.split(","):
+        coding, _, params = entry.partition(";")
+        coding = coding.strip().lower()
+        if not coding:
+            continue
+        quality = 1.0
+        for param in params.split(";"):
+            name, sep, value = param.partition("=")
+            if name.strip().lower() != "q":
+                continue
+            if not sep:
+                break
+            try:
+                quality = float(value.strip())
+            except ValueError:
+                # An unparseable qvalue makes the whole entry invalid; treat
+                # the coding as unacceptable rather than guess.
+                quality = 0.0
+            else:
+                # Per RFC 9110 a qvalue must be a number in the range 0.000 to
+                # 1.000; any other finite value (e.g. ``inf``) is invalid.
+                if not math.isfinite(quality) or not 0.0 <= quality <= 1.0:
+                    quality = 0.0
+            break
+        if quality > 0:
+            accepted.add(coding)
+    return accepted
 
 
 def scantree(root: str | PathLike[str]) -> Iterator[tuple[str, os.stat_result]]:

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -126,6 +126,46 @@ def test_get_accept_gzip(server, files):
     assert response.headers["Vary"] == "Accept-Encoding"
 
 
+@pytest.mark.parametrize(
+    "accept_encoding",
+    [
+        "gzip;q=0",
+        "gzip;q=0.0",
+        "gzip; q=0",
+        "identity, gzip;q=0",
+    ],
+)
+def test_get_gzip_refused_by_qvalue(server, files, accept_encoding):
+    # A qvalue of zero means the client will not accept that coding.
+    response = server.get(files.gzip_url, headers={"Accept-Encoding": accept_encoding})
+    assert response.content == files.gzip_content
+    assert "Content-Encoding" not in response.headers
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+@pytest.mark.parametrize(
+    "accept_encoding",
+    [
+        "x-gzip-really",
+        "supergzip",
+        "gzip spam brotli",
+    ],
+)
+def test_get_gzip_not_matched_as_substring(server, files, accept_encoding):
+    # The coding must appear as a whole token, not anywhere in the header.
+    response = server.get(files.gzip_url, headers={"Accept-Encoding": accept_encoding})
+    assert response.content == files.gzip_content
+    assert "Content-Encoding" not in response.headers
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+def test_get_accept_gzip_with_qvalue(server, files):
+    response = server.get(files.gzip_url, headers={"Accept-Encoding": "gzip;q=0.5"})
+    assert response.content == files.gzip_content
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
 def test_cannot_directly_request_gzipped_file(server, files):
     response = server.get(f"{files.gzip_url}.gz")
     assert_is_default_response(response)

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -19,7 +19,14 @@ import pytest
 
 from servestatic import ServeStatic
 from servestatic.base import ServeStaticBase
-from servestatic.responders import FileEntry, MissingFileError, NotARegularFileError, Redirect, StaticFile
+from servestatic.responders import (
+    FileEntry,
+    MissingFileError,
+    NotARegularFileError,
+    Redirect,
+    StaticFile,
+    parse_accept_encoding,
+)
 
 from .utils import AppServer, Files
 
@@ -164,6 +171,25 @@ def test_get_accept_gzip_with_qvalue(server, files):
     assert response.content == files.gzip_content
     assert response.headers["Content-Encoding"] == "gzip"
     assert response.headers["Vary"] == "Accept-Encoding"
+
+
+@pytest.mark.parametrize(
+    "header, expected",
+    [
+        ("gzip", {"gzip"}),
+        ("gzip, br", {"gzip", "br"}),
+        ("gzip;", {"gzip"}),
+        ("Brotli", {"brotli"}),
+        ("gzip ; q=0.5", {"gzip"}),
+        ("gzip;foo=bar", {"gzip"}),
+        ("gzip;q=abc", set()),
+        ("gzip; q", {"gzip"}),
+        (",,", set()),
+        ("", set()),
+    ],
+)
+def test_parse_accept_encoding(header, expected):
+    assert parse_accept_encoding(header) == expected
 
 
 def test_cannot_directly_request_gzipped_file(server, files):

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -25,8 +25,8 @@ from servestatic.responders import (
     NotARegularFileError,
     Redirect,
     StaticFile,
-    parse_accept_encoding,
 )
+from servestatic.utils import parse_accept_encoding
 
 from .utils import AppServer, Files
 
@@ -186,6 +186,25 @@ def test_get_accept_gzip_with_qvalue(server, files):
         ("gzip; q", {"gzip"}),
         (",,", set()),
         ("", set()),
+        # Spaces around commas, mixed case, and surrounding whitespace.
+        (" gzip , br ", {"gzip", "br"}),
+        ("GZIP, BroTLI", {"gzip", "brotli"}),
+        ("gzip,,br", {"gzip", "br"}),
+        ("gzip,", {"gzip"}),
+        # OWS around the q= separator.
+        ("gzip ; q = 0.5", {"gzip"}),
+        ("gzip;q =0", set()),
+        # Multiple parameters after the coding.
+        ("gzip;foo=bar;q=0", set()),
+        ("gzip;evil;q=0.5", {"gzip"}),
+        # Quoted qvalues are not valid per RFC 9110; treated as unacceptable.
+        ('gzip; q="0.5"', set()),
+        # Unparseable qvalues are treated as unacceptable.
+        ("gzip;q=1e999", set()),
+        ("gzip;q=-0.5", set()),
+        ("gzip;q=", set()),
+        # qvalue of exactly 1.0 and ordering of params.
+        ("gzip;q=1;foo=bar", {"gzip"}),
     ],
 )
 def test_parse_accept_encoding(header, expected):


### PR DESCRIPTION
Equivalent of [evansd/whitenoise#707](https://github.com/evansd/whitenoise/pull/707) by `ArockiaRajamanickam`, which fixes [whitenoise#352](https://github.com/evansd/whitenoise/issues/352). ServeStatic shares the same underlying static-serving code (forked from WhiteNoise) and is affected by the same bug.

Original work is attributed via a `Co-authored-by` trailer on the first commit.

## What was happening

`get_alternatives()` built a regex per available encoding, `re.compile(rf"\b{encoding}\b")`, and `get_path_and_headers()` searched it against the raw `Accept-Encoding` header. That produced wrong results:

```
Accept-Encoding              got    want
gzip;q=0                     gzip   None   WRONG
gzip;q=0.0                   gzip   None   WRONG
gzip; q=0                    gzip   None   WRONG
identity, gzip;q=0           gzip   None   WRONG
x-gzip-really                gzip   None   WRONG
gzip spam brotli             gzip   None   WRONG
```

A refused coding (`gzip;q=0`) was served, and any token merely containing `gzip` (e.g. `x-gzip-really`, where `\b` treats `-` as a word break) matched.

## The change

`Accept-Encoding` is now parsed into the set of codings the client will accept per RFC 9110 section 12.5.3. Alternatives store their coding name rather than a compiled regex, entries with a zero qvalue are dropped, and matching is on whole tokens.

Deliberately preserved existing behaviour:
- `*` and empty headers are still treated as "no encoding supported".
- An uncompressed file remains an acceptable fallback.
- Alternatives are still sorted smallest-first ("prefer the smallest response").

One incidental tidy: `import re` became unused in `responders.py` and was removed.

## Tests

Added to `tests/test_servestatic.py` beside the existing `test_get_accept_*` tests: parametrised cases for qvalue refusal, for substring non-matching, and one confirming a non-zero qvalue still gets gzip.

Reverting the source change while keeping the tests fails them, so they bind to the defect. Full suite: 370 passed, 10 skipped. `ruff format --check` is clean, `responders.py` is at 100% coverage, and the strict docs build passes.