### PR TITLE
Keep CORS and cache headers on 416 and 304 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
-- No changes here, yet!
+### Fixed
+
+- Keep CORS / cache headers on `416` (Range Not Satisfiable) and `304` (Not Modified) responses, so that cross-origin media probes are not broken.
 
 ## [4.3.2] - 2026-09-01
 

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -42,6 +42,7 @@ NOT_ALLOWED_RESPONSE = Response(
 # Headers which should be returned with a 304 Not Modified response as
 # specified here: https://tools.ietf.org/html/rfc7232#section-4.1
 NOT_MODIFIED_HEADERS = (
+    "Access-Control-Allow-Origin",
     "Cache-Control",
     "Content-Location",
     "Date",
@@ -184,7 +185,7 @@ class StaticFile:
             raise ValueError(msg)
         start, end = self.get_byte_range(range_header, size)
         if start > end:
-            return self.get_range_not_satisfiable_response(file_handle, size)
+            return self.get_range_not_satisfiable_response(file_handle, size, headers)
         if file_handle is not None:
             file_handle = SlicedFile(file_handle, start, end)
         headers.extend((
@@ -213,7 +214,7 @@ class StaticFile:
             raise ValueError(msg)
         start, end = self.get_byte_range(range_header, size)
         if start > end:
-            return await self.aget_range_not_satisfiable_response(file_handle, size)
+            return await self.aget_range_not_satisfiable_response(file_handle, size, headers)
         sliced_file: AsyncSlicedFile | None = None
         if file_handle is not None:
             sliced_file = AsyncSlicedFile(file_handle, start, end)
@@ -249,23 +250,35 @@ class StaticFile:
         return start, end
 
     @staticmethod
-    def get_range_not_satisfiable_response(file_handle: BufferedIOBase | None, size: int) -> Response:
+    def get_range_not_satisfiable_response(
+        file_handle: BufferedIOBase | None,
+        size: int,
+        headers: list[tuple[str, str | None]] | None = None,
+    ) -> Response:
         if file_handle is not None:
             file_handle.close()
+        response_headers = list(headers) if headers else []
+        response_headers.append(("Content-Range", f"bytes */{size}"))
         return Response(
             HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
-            [("Content-Range", f"bytes */{size}")],
+            response_headers,
             None,
         )
 
     @staticmethod
-    async def aget_range_not_satisfiable_response(file_handle: AsyncFile | None, size: int) -> Response:
+    async def aget_range_not_satisfiable_response(
+        file_handle: AsyncFile | None,
+        size: int,
+        headers: list[tuple[str, str | None]] | None = None,
+    ) -> Response:
         """Variant of `get_range_not_satisfiable_response` that works with
         async file objects. Async file handles do not need to be closed, since they
         are only opened via context managers while being dispatched."""
+        response_headers = list(headers) if headers else []
+        response_headers.append(("Content-Range", f"bytes */{size}"))
         return Response(
             HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
-            [("Content-Range", f"bytes */{size}")],
+            response_headers,
             None,
         )
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -114,6 +114,8 @@ def test_out_of_range_error(application, test_files):
     asyncio.run(application(scope, receive, send))
     assert send.status == 416
     assert send.headers[b"content-range"] == b"bytes */%d" % len(test_files.js_content)
+    assert send.headers[b"access-control-allow-origin"] == b"*"
+    assert b"cache-control" in send.headers
 
 
 def test_wrong_method_type(application, test_files):

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -136,6 +136,7 @@ def test_not_modified_exact(server, files):
     last_mod = response.headers["Last-Modified"]
     response = server.get(files.js_url, headers={"If-Modified-Since": last_mod})
     assert response.status_code == 304
+    assert response.headers.get("Access-Control-Allow-Origin") == "*"
 
 
 def test_not_modified_future(server, files):
@@ -317,6 +318,8 @@ def test_out_of_range_error(server, files):
     response = server.get(files.js_url, headers={"Range": "bytes=10000-11000"})
     assert response.status_code == 416
     assert response.headers["Content-Range"] == f"bytes */{len(files.js_content)}"
+    assert response.headers.get("Access-Control-Allow-Origin") == "*"
+    assert "Cache-Control" in response.headers
 
 
 def test_warn_about_missing_directories(application):


### PR DESCRIPTION
Ports the fix from [whitenoise PR #713](https://github.com/evansd/whitenoise/pull/713) (and fixes the equivalent of [whitenoise #711](https://github.com/evansd/whitenoise/issues/711)).

### Problem

The 416 (Range Not Satisfiable) response dropped every header except `Content-Range`, and the 304 (Not Modified) response omitted `Access-Control-Allow-Origin`. This breaks cross-origin media probes, where a client checks range availability and expects the CORS header on both statuses.

### Changes

- Add `Access-Control-Allow-Origin` to `NOT_MODIFIED_HEADERS` so 304 responses keep the CORS header.
- Pass the base headers through to the (sync and async) `get_range_not_satisfiable_response` / `aget_range_not_satisfiable_response` so 416 responses retain CORS and cache headers alongside `Content-Range`.

> Note: The single-byte-range portion of the original whitenoise PR (`bytes=0-0`, `bytes=-1` as satisfiable) is already handled in ServeStatic via the `start > end` check and existing tests, so only the header-preservation portion is ported here.

### Testing

- Updated `test_not_modified_exact` to assert the CORS header on 304.
- Updated `test_out_of_range_error` (sync) and `test_asgi.py::test_out_of_range_error` (async) to assert CORS and cache headers on 416.
- Full suite: `344 passed, 10 skipped`. Pyright: `0 errors`. Changelog: valid.