### PR TITLE
Fix unhandled ValueError on NUL-byte request paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Don't forget to remove deprecated code on each major release!
 ### Fixed
 
 - Keep CORS / cache headers on `416` (Range Not Satisfiable) and `304` (Not Modified) responses, so that cross-origin media probes are not broken.
+- Prevent an unhandled `ValueError` crash when a request path contains a NUL byte (`%00`) that survives normalization, which could be triggered by an unauthenticated request to crash the server (DoS / log-flood).
 
 ## [4.3.2] - 2026-09-01
 

--- a/src/servestatic/base.py
+++ b/src/servestatic/base.py
@@ -162,8 +162,15 @@ class ServeStaticBase:
         if getattr(self, "allow_unsafe_symlinks", False):
             return True
 
-        resolved_root = os.path.realpath(normalized_root)
-        resolved_path = os.path.realpath(normalized_path)
+        try:
+            resolved_root = os.path.realpath(normalized_root)
+            resolved_path = os.path.realpath(normalized_path)
+        except ValueError:
+            # A raw NUL byte (e.g. from a request path containing %00) survives
+            # normpath() but makes realpath() raise. Treat such a path as being
+            # outside the root (i.e. not found/forbidden) rather than letting an
+            # unhandled ValueError propagate and crash the request.
+            return False
         return self._path_is_within(resolved_root, resolved_path)
 
     @staticmethod

--- a/tests/test_servestatic.py
+++ b/tests/test_servestatic.py
@@ -571,6 +571,22 @@ def test_path_within_root_normalizes_drive_root_separator(monkeypatch):
     assert app.path_within_root("C:\\", "C:\\static\\file.js")
 
 
+def test_path_within_root_returns_false_when_realpath_raises_value_error(monkeypatch):
+    """A NUL byte that survives normpath must not crash: treat it as outside root."""
+    app = DummyServeStaticBase(None)
+
+    def fake_path_is_within(root, path):
+        return True
+
+    def fake_realpath(value):
+        raise ValueError("embedded null character")
+
+    monkeypatch.setattr(app, "_path_is_within", fake_path_is_within)
+    monkeypatch.setattr(os.path, "realpath", fake_realpath)
+
+    assert app.path_within_root("/srv/static", "/srv/static/hello.txt\x00.evil") is False
+
+
 def test_is_compressed_variant_detects_zstd_suffix_with_cache():
     cache = {"/tmp/app.js": fake_stat_entry(st_mtime=1)}
     assert DummyServeStaticBase.is_compressed_variant("/tmp/app.js.zstd", stat_cache=cache)


### PR DESCRIPTION
## Description

Resolves an unhandled `ValueError` (crash) when a request path contains a NUL byte that survives normalization.

`ServeStaticBase.path_within_root()` calls `os.path.realpath()` as part of its symlink-resolving containment check. A raw NUL byte (e.g. from a request path containing `%00`) survives `os.path.normpath()` but makes `os.path.realpath()` raise `ValueError: embedded null character in path`. Nothing catches it, so the request crashes with a `500` and a full traceback per request — an unauthenticated single-request DoS / log-flood (amplified by Django's technical error page when `DEBUG=True`).

This change catches `ValueError` around the `realpath()` calls and treats such a path as being **outside the root** (i.e. not found / forbidden), consistent with how other invalid paths are handled, rather than letting it propagate as an unhandled server error. The primary path-traversal / symlink-escape containment logic is unchanged.

### Reproduction (verified before fix)
```python
sv.path_within_root(root, root + "/hello.txt\x00.evil")
# Before: ValueError: lstat: embedded null character in path (uncaught)
# After:  False
```

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been developed for bug fixes or new functionality.
- [x] The changelog has been updated, if necessary.
- [x] Documentation has been updated, if necessary.
- [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>