### PR TITLE
Add support for ASGI `pathsend` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Don't forget to remove deprecated code on each major release!
 
 ## [Unreleased]
 
+### Added
+
+- Support the ASGI `http.response.pathsend` extension for full-file sends. When the ASGI server advertises this extension (e.g. Granian), ServeStatic now offloads the file transmission to the server via `pathsend` instead of streaming the file through Python file IO. Range (sliced) requests continue to stream over `http.response.body` since `pathsend` has no slicing support.
+
 ### Changed
 
 - Make the standalone ASGI/WSGI serving core compatible with the trio async backend. Thread-offload now detects the running async library (via sniffio, lazily and optionally) and dispatches to asyncio or trio, so ServeStatic no longer returns empty responses under trio-based servers (e.g. Anycorn `--worker-class trio`).

--- a/docs/src/dictionary.txt
+++ b/docs/src/dictionary.txt
@@ -47,6 +47,7 @@ uncached
 substring
 webserver
 anycorn
+granian
 asyncio
 sniffio
 trio

--- a/docs/src/django-faq.md
+++ b/docs/src/django-faq.md
@@ -8,7 +8,7 @@ Alternatively, if you are only utilizing Django Compressor for its minification 
 
 ## Can I use `ServeStatic` for media files?
 
-`ServeStatic` is not suitable for serving user-uploaded "media" files. For one thing, as described above, it only checks for static files at startup and so files added after the app starts won't be seen. More importantly though, serving user-uploaded files from the same domain as your main application is a security risk (this [blog post](https://security.googleblog.com/2012/08/content-hosting-for-modern-web.html) from Google security describes the problem well). And in addition to that, using local disk to store and serve your user media makes it harder to scale your application across multiple machines.
+`ServeStatic` is not suitable for serving user-uploaded "media" files. For one thing, as described above, it only checks for static files at startup and so files added after the app starts won't be seen. More importantly though, serving user-uploaded files from the same domain as your main application is a security risk (this [blog post](https://grsee.com/resources/pentesting/securing-file-uploads-risks-and-strategies-to-consider/) describes the problem well). And in addition to that, using local disk to store and serve your user media makes it harder to scale your application across multiple machines.
 
 For all these reasons, it's much better to store files on a separate dedicated storage service and serve them to users from there. The [django-storages](https://django-storages.readthedocs.io/) library provides many options e.g. Amazon S3, Azure Storage, and Rackspace CloudFiles.
 

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from asgiref.compatibility import guarantee_single_callable
-from asgiref.typing import HTTPResponseBodyEvent, HTTPResponseStartEvent
+from asgiref.typing import HTTPResponseBodyEvent, HTTPResponsePathsendEvent, HTTPResponseStartEvent
 
 from servestatic.base import ServeStaticBase
 from servestatic.utils import decode_path_info, get_block_size, run_async_in_thread
@@ -68,8 +68,13 @@ class FileServerASGI:
         }
         wsgi_headers["QUERY_STRING"] = scope["query_string"].decode("latin-1")
 
+        # Check whether the ASGI server advertises the `http.response.pathsend`
+        # extension for more efficient file transmission (e.g. os.sendfile).
+        extensions = scope.get("extensions") or {}
+        pathsend_supported = "http.response.pathsend" in extensions
+
         # Get the ServeStatic file response
-        response = await self.static_file.aget_response(scope["method"], wsgi_headers)
+        response = await self.static_file.aget_response(scope["method"], wsgi_headers, pathsend=pathsend_supported)
 
         # Start a new HTTP response for the file
         await send(
@@ -85,6 +90,14 @@ class FileServerASGI:
                 trailers=False,
             )
         )
+
+        # A pathsend response has no body streamed by us: the server sends the
+        # file located at `response.path` (a full-file send only).
+        # `HTTPResponsePathsendEvent` is not part of asgiref's `ASGISendEvent`
+        # union, so cast it to satisfy the send callable's type signature.
+        if response.file is None and response.path is not None:
+            await send(cast("Any", HTTPResponsePathsendEvent(type="http.response.pathsend", path=response.path)))
+            return
 
         # Head responses have no body, so we terminate early
         if response.file is None:

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from asgiref.compatibility import guarantee_single_callable
-from asgiref.typing import HTTPResponseBodyEvent, HTTPResponsePathsendEvent, HTTPResponseStartEvent
+from asgiref.typing import HTTPResponseBodyEvent, HTTPResponseStartEvent
 
 from servestatic.base import ServeStaticBase
 from servestatic.utils import decode_path_info, get_block_size, run_async_in_thread
@@ -93,10 +93,12 @@ class FileServerASGI:
 
         # A pathsend response has no body streamed by us: the server sends the
         # file located at `response.path` (a full-file send only).
-        # `HTTPResponsePathsendEvent` is not part of asgiref's `ASGISendEvent`
-        # union, so cast it to satisfy the send callable's type signature.
+        # `http.response.pathsend` is not part of asgiref's `ASGISendEvent` union,
+        # and `HTTPResponsePathsendEvent` is only available on asgiref >= 3.8, so
+        # construct the event inline and cast it to satisfy the send callable's
+        # type signature without a hard runtime dependency on that symbol.
         if response.file is None and response.path is not None:
-            await send(cast("Any", HTTPResponsePathsendEvent(type="http.response.pathsend", path=response.path)))
+            await send(cast("Any", {"type": "http.response.pathsend", "path": response.path}))
             return
 
         # Head responses have no body, so we terminate early

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -19,17 +19,22 @@ if TYPE_CHECKING:
 
 
 class Response:  # noqa: B903
-    __slots__ = ("file", "headers", "status")
+    __slots__ = ("file", "headers", "path", "status")
 
     def __init__(
         self,
         status: HTTPStatus,
         headers: list[tuple[str, str | None]],
         file: BufferedIOBase | AsyncFile | AsyncSlicedFile | None,
+        path: str | None = None,
     ) -> None:
         self.status = status
         self.headers = headers
         self.file = file
+        # Absolute path of the file being sent. This is only populated for a
+        # full-file (non-sliced) response so the ASGI server can offload the
+        # file transmission via the `http.response.pathsend` extension.
+        self.path = path
 
 
 NOT_ALLOWED_RESPONSE = Response(
@@ -145,25 +150,52 @@ class StaticFile:
                 return self.get_range_response(range_header, headers, file_handle)
         return Response(HTTPStatus.OK, headers, file_handle)
 
-    async def aget_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
+    async def aget_response(
+        self,
+        method: str,
+        request_headers: Mapping[str, str],
+        *,
+        pathsend: bool = False,
+    ) -> Response:
         """Variant of `get_response` that works with async HTTP requests.
-        To minimize code duplication, `request_headers` conforms to WSGI header spec."""
+        To minimize code duplication, `request_headers` conforms to WSGI header spec.
+
+        When `pathsend` is True, the caller has confirmed that the underlying ASGI
+        server advertises the `http.response.pathsend` extension. In that case we
+        skip opening an async file handle for a full-file send and instead populate
+        `Response.path`, allowing the server to transmit the file by path.
+        """
         if method not in {"GET", "HEAD"}:
             return NOT_ALLOWED_RESPONSE
         if self.is_not_modified(request_headers):
             return self.not_modified_response
         path, headers = self.get_path_and_headers(request_headers)
-        # We do not await this async file handle to allow us the option of opening
-        # it in a thread later
-        file_handle = AsyncFile(path, "rb") if method != "HEAD" else None
         range_header = request_headers.get("HTTP_RANGE")
         if range_header:
             # If we can't interpret the Range request for any reason then
             # just ignore it and return the standard response (this
-            # behaviour is allowed by the spec)
+            # behaviour is allowed by the spec). Range requests always require a
+            # real file handle since pathsend does not support slicing.
+            range_file = AsyncFile(path, "rb") if method != "HEAD" else None
             with contextlib.suppress(ValueError):
-                return await self.aget_range_response(range_header, headers, file_handle)
-        return Response(HTTPStatus.OK, headers, file_handle)
+                return await self.aget_range_response(range_header, headers, range_file)
+            # The Range header was uninterpretable; fall through to a full send.
+            if range_file is not None:
+                await range_file.close()
+            if pathsend and method != "HEAD":
+                # The server will transmit the whole file by path, so discard the
+                # handle we created for range handling.
+                return Response(HTTPStatus.OK, headers, None, path=path)
+            return Response(HTTPStatus.OK, headers, range_file, path=path if method != "HEAD" else None)
+        if method == "HEAD":
+            return Response(HTTPStatus.OK, headers, None)
+        if pathsend:
+            # The server will stream the file by path, so we open no file handle
+            # (and create no async file thread pool) on our side.
+            return Response(HTTPStatus.OK, headers, None, path=path)
+        # We do not await this async file handle to allow us the option of opening
+        # it in a thread later.
+        return Response(HTTPStatus.OK, headers, AsyncFile(path, "rb"), path=path)
 
     def get_range_response(
         self,
@@ -391,7 +423,13 @@ class Redirect:
             return Response(self.response.status, headers, None)
         return self.response
 
-    async def aget_response(self, method: str, request_headers: Mapping[str, str]) -> Response:
+    async def aget_response(
+        self,
+        method: str,
+        request_headers: Mapping[str, str],
+        *,
+        pathsend: bool = False,
+    ) -> Response:
         return self.get_response(method, request_headers)
 
 

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -180,12 +180,13 @@ class StaticFile:
             with contextlib.suppress(ValueError):
                 return await self.aget_range_response(range_header, headers, range_file)
             # The Range header was uninterpretable; fall through to a full send.
-            if range_file is not None:
-                await range_file.close()
             if pathsend and method != "HEAD":
                 # The server will transmit the whole file by path, so discard the
                 # handle we created for range handling.
+                if range_file is not None:
+                    await range_file.close()
                 return Response(HTTPStatus.OK, headers, None, path=path)
+            # Otherwise keep the (open) handle so we can stream the full file.
             return Response(HTTPStatus.OK, headers, range_file, path=path if method != "HEAD" else None)
         if method == "HEAD":
             return Response(HTTPStatus.OK, headers, None)

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -8,7 +8,7 @@ from email.utils import formatdate, parsedate
 from http import HTTPStatus
 from io import BufferedIOBase
 from time import mktime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import quote
 from wsgiref.headers import Headers
 
@@ -184,7 +184,7 @@ class StaticFile:
                 # The server will transmit the whole file by path, so discard the
                 # handle we created for range handling. (range_file is always
                 # non-None here since method != HEAD creates it above.)
-                await range_file.close()
+                await cast("AsyncFile", range_file).close()
                 return Response(HTTPStatus.OK, headers, None, path=path)
             # Otherwise keep the (open) handle so we can stream the full file.
             return Response(HTTPStatus.OK, headers, range_file, path=path if method != "HEAD" else None)

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -182,9 +182,9 @@ class StaticFile:
             # The Range header was uninterpretable; fall through to a full send.
             if pathsend and method != "HEAD":
                 # The server will transmit the whole file by path, so discard the
-                # handle we created for range handling.
-                if range_file is not None:
-                    await range_file.close()
+                # handle we created for range handling. (range_file is always
+                # non-None here since method != HEAD creates it above.)
+                await range_file.close()
                 return Response(HTTPStatus.OK, headers, None, path=path)
             # Otherwise keep the (open) handle so we can stream the full file.
             return Response(HTTPStatus.OK, headers, range_file, path=path if method != "HEAD" else None)

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -195,6 +195,20 @@ def test_pathsend_malformed_range_falls_back_to_full_send(application, test_file
     assert os.path.normpath(send[1]["path"]) == os.path.normpath(os.path.join(test_files.directory, test_files.js_path))
 
 
+def test_malformed_range_falls_back_to_full_send_without_pathsend(application, test_files):
+    """When pathsend is not advertised, an uninterpretable Range header is
+    ignored (per spec) and the full file is streamed via `http.response.body`.
+    Regression test: the discarded range handle must not be reused, which would
+    otherwise raise `ValueError: I/O operation on closed file`."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "headers": [(b"range", b"bytes=abc")]})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send.body == test_files.js_content
+    assert all(msg["type"] != "http.response.pathsend" for msg in send.message)
+
+
 def test_pathsend_head_malformed_range_falls_back_to_headers(application, test_files):
     """A malformed Range header on a HEAD request is ignored; because HEAD has no
     body it must not emit a pathsend message, just the response headers."""

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -139,6 +139,96 @@ def test_large_static_file(application, test_files):
     assert b"text/plain" in send.headers[b"content-type"]
 
 
+def test_pathsend_uses_pathsend_event(application, test_files):
+    """When the server advertises pathsend, a full-file GET is sent via
+    `http.response.pathsend` instead of streaming the body."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "extensions": {"http.response.pathsend": {}}})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send[1]["type"] == "http.response.pathsend"
+    assert send[1]["path"] == os.path.join(test_files.directory, test_files.js_path)
+    assert len(send.message) == 2
+
+
+def test_pathsend_not_used_when_not_advertised(application, test_files):
+    """Without the pathsend extension in scope, ServeStatic streams the body
+    via `http.response.body` as usual."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js"})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.body == test_files.js_content
+    assert all(msg["type"] != "http.response.pathsend" for msg in send.message)
+
+
+def test_pathsend_range_still_streams_body(application, test_files):
+    """Pathsend does not support slicing, so a Range request must keep
+    streaming the sliced body even when the server advertises pathsend."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=0-13")],
+        "extensions": {"http.response.pathsend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 206
+    assert send.body == test_files.js_content[:14]
+    assert all(msg["type"] != "http.response.pathsend" for msg in send.message)
+
+
+def test_pathsend_malformed_range_falls_back_to_full_send(application, test_files):
+    """An uninterpretable Range header is ignored (per spec), so the full file is
+    sent via pathsend when the server advertises it."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=abc")],
+        "extensions": {"http.response.pathsend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send[1]["type"] == "http.response.pathsend"
+    assert send[1]["path"] == os.path.join(test_files.directory, test_files.js_path)
+
+
+def test_pathsend_head_malformed_range_falls_back_to_headers(application, test_files):
+    """A malformed Range header on a HEAD request is ignored; because HEAD has no
+    body it must not emit a pathsend message, just the response headers."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "method": "HEAD",
+        "headers": [(b"range", b"bytes=abc")],
+        "extensions": {"http.response.pathsend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send.body == b""
+    assert len(send.message) == 2
+    assert send[1]["type"] == "http.response.body"
+
+
+def test_pathsend_head_has_no_body(application, test_files):
+    """HEAD requests must not emit a pathsend body message."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "method": "HEAD",
+        "extensions": {"http.response.pathsend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send.body == b""
+    assert len(send.message) == 2
+    assert send[1]["type"] == "http.response.body"
+
+
 def test_async_file_del_does_not_join_current_thread(test_files, capsys):
     file_path = str(Path(test_files.directory) / test_files.js_path)
     holder = {"async_file": servestatic_utils.AsyncFile(file_path, "rb")}

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -148,7 +148,7 @@ def test_pathsend_uses_pathsend_event(application, test_files):
     asyncio.run(application(scope, receive, send))
     assert send.status == 200
     assert send[1]["type"] == "http.response.pathsend"
-    assert send[1]["path"] == os.path.join(test_files.directory, test_files.js_path)
+    assert os.path.normpath(send[1]["path"]) == os.path.normpath(os.path.join(test_files.directory, test_files.js_path))
     assert len(send.message) == 2
 
 
@@ -192,7 +192,7 @@ def test_pathsend_malformed_range_falls_back_to_full_send(application, test_file
     asyncio.run(application(scope, receive, send))
     assert send.status == 200
     assert send[1]["type"] == "http.response.pathsend"
-    assert send[1]["path"] == os.path.join(test_files.directory, test_files.js_path)
+    assert os.path.normpath(send[1]["path"]) == os.path.normpath(os.path.join(test_files.directory, test_files.js_path))
 
 
 def test_pathsend_head_malformed_range_falls_back_to_headers(application, test_files):


### PR DESCRIPTION
## Description

Add support for the ASGI [`http.response.pathsend`](https://asgi.readthedocs.io/en/latest/extensions.html#path-send) extension.

When the ASGI server advertises this extension (e.g. [Granian](https://github.com/emmett-framework/granian)), ServeStatic now offloads full-file transmissions to the server via a `http.response.pathsend` message instead of streaming the file through Python file IO. Depending on implementation, it is possible for `pathsend` to be more efficient (e.g. via `os.sendfile` / `loop.sendfile`) than our own Python file IO implementation.

Because the `pathsend` spec has no slicing support (ref: https://github.com/django/asgiref/issues/469), range (sliced) requests continue to stream over `http.response.body` as before. HEAD requests do not emit a body message.

Key changes:
- `Response` now carries an optional absolute `path` for full-file sends.
- `StaticFile.aget_response()` accepts a `pathsend` flag; when enabled it avoids opening an async file handle (and its thread pool) for full-file sends and instead populates `Response.path`. Range responses always create a real file handle.
- `FileServerASGI` checks the scope's advertised `extensions` and dispatches a `http.response.pathsend` event for full-file sends.
- Added tests covering: pathsend dispatch, no dispatch when not advertised, range requests still streaming, HEAD having no body, and malformed-range fallback.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

Closes #119

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>