### PR TITLE
Add support for ASGI `zerocopysend` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ Don't forget to remove deprecated code on each major release!
 ### Added
 
 - Support the ASGI `http.response.pathsend` extension for full-file sends. When the ASGI server advertises this extension (e.g. Granian), ServeStatic now offloads the file transmission to the server via `pathsend` instead of streaming the file through Python file IO. Range (sliced) requests continue to stream over `http.response.body` since `pathsend` has no slicing support.
-
-- Support the ASGI `http.response.zerocopysend` extension (e.g. nonecorn or anycorn). When the ASGI server advertises this extension, ServeStatic offloads file transmission to the server via `os.sendfile`. Unlike `pathsend`, `zerocopysend` supports slicing, so both full-file and Range (sliced) requests are transmitted zero-copy. When a server advertises both extensions, `zerocopysend` is preferred because it handles sliced sends as well.
+- Support the ASGI `http.response.zerocopysend` extension (e.g. nonecorn or anycorn). When the ASGI server advertises this extension, ServeStatic offloads file transmission to the server via `zerocopysend`. Unlike `pathsend`, `zerocopysend` supports slicing, so both full-file and Range (sliced) requests are transmitted zero-copy. When a server advertises both extensions, `zerocopysend` is preferred for performance reasons.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Don't forget to remove deprecated code on each major release!
 
 - Support the ASGI `http.response.pathsend` extension for full-file sends. When the ASGI server advertises this extension (e.g. Granian), ServeStatic now offloads the file transmission to the server via `pathsend` instead of streaming the file through Python file IO. Range (sliced) requests continue to stream over `http.response.body` since `pathsend` has no slicing support.
 
+- Support the ASGI `http.response.zerocopysend` extension (e.g. nonecorn or anycorn). When the ASGI server advertises this extension, ServeStatic offloads file transmission to the server via `os.sendfile`. Unlike `pathsend`, `zerocopysend` supports slicing, so both full-file and Range (sliced) requests are transmitted zero-copy. When a server advertises both extensions, `zerocopysend` is preferred because it handles sliced sends as well.
+
 ### Changed
 
 - Make the standalone ASGI/WSGI serving core compatible with the trio async backend. Thread-offload now detects the running async library (via sniffio, lazily and optionally) and dispatches to asyncio or trio, so ServeStatic no longer returns empty responses under trio-based servers (e.g. Anycorn `--worker-class trio`).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Visit the [documentation](https://archmonger.github.io/ServeStatic/) to get star
 
 The short answer to this is that if you care about performance and efficiency then you should be using `ServeStatic` behind a CDN (such as CloudFront). Due to the caching headers `ServeStatic` sends, the vast majority of static requests will be served directly by the CDN without touching your application, so it really doesn't make much difference how efficient `ServeStatic` is.
 
-That said, `ServeStatic` is pretty efficient. Because it only has to serve a fixed set of files it does all the work of finding files and determining the correct headers upfront on initialization. Requests can then be served with little more than a dictionary lookup to find the appropriate response. Also, when used with gunicorn (and most other WSGI servers) the actual business of pushing the file down the network interface is handled by the kernel's very efficient `sendfile` syscall, not by Python.
+That said, `ServeStatic` is pretty efficient. Because it only has to serve a fixed set of files it does all the work of finding files and determining the correct headers upfront on initialization. Requests can then be served with little more than a dictionary lookup to find the appropriate response. Also, when used with a `file_wrapper` compatible WSGI server (e.g. `gunicorn`) or `zerocopysend`/`pathsend` compatible ASGI server (e.g. `granian`, `anycorn`, `nonecorn`) the actual business of pushing the file down the network interface is handled by the kernel's very efficient `sendfile` syscall, not by Python.
 
 ### Shouldn't I be pushing my static files to S3 (using Django-Storages)?
 

--- a/docs/src/dictionary.txt
+++ b/docs/src/dictionary.txt
@@ -48,6 +48,7 @@ substring
 webserver
 anycorn
 granian
+nonecorn
 asyncio
 sniffio
 trio

--- a/src/servestatic/asgi.py
+++ b/src/servestatic/asgi.py
@@ -68,13 +68,17 @@ class FileServerASGI:
         }
         wsgi_headers["QUERY_STRING"] = scope["query_string"].decode("latin-1")
 
-        # Check whether the ASGI server advertises the `http.response.pathsend`
-        # extension for more efficient file transmission (e.g. os.sendfile).
+        # Check which efficient file-transmission extensions the ASGI server
+        # advertises (e.g. os.sendfile). `zerocopysend` supports slicing, so it is
+        # preferred when available; `pathsend` is a full-file-only fallback.
         extensions = scope.get("extensions") or {}
         pathsend_supported = "http.response.pathsend" in extensions
+        zerocopysend_supported = "http.response.zerocopysend" in extensions
 
         # Get the ServeStatic file response
-        response = await self.static_file.aget_response(scope["method"], wsgi_headers, pathsend=pathsend_supported)
+        response = await self.static_file.aget_response(
+            scope["method"], wsgi_headers, pathsend=pathsend_supported, zerocopysend=zerocopysend_supported
+        )
 
         # Start a new HTTP response for the file
         await send(
@@ -99,6 +103,22 @@ class FileServerASGI:
         # type signature without a hard runtime dependency on that symbol.
         if response.file is None and response.path is not None:
             await send(cast("Any", {"type": "http.response.pathsend", "path": response.path}))
+            return
+
+        # A zero-copy response carries a real fd-backed file object that the server
+        # transmits via `os.sendfile`. The ASGI spec requires the application to
+        # close the descriptor once the send completes.
+        if response.offset is not None and response.file is not None:
+            event: dict[str, object] = {
+                "type": "http.response.zerocopysend",
+                "file": response.file,
+                "offset": response.offset,
+                "more_body": False,
+            }
+            if response.count is not None:
+                event["count"] = response.count
+            await send(cast("Any", event))
+            response.file.close()
             return
 
         # Head responses have no body, so we terminate early

--- a/src/servestatic/responders.py
+++ b/src/servestatic/responders.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class Response:  # noqa: B903
-    __slots__ = ("file", "headers", "path", "status")
+    __slots__ = ("count", "file", "headers", "offset", "path", "status")
 
     def __init__(
         self,
@@ -27,6 +27,9 @@ class Response:  # noqa: B903
         headers: list[tuple[str, str | None]],
         file: BufferedIOBase | AsyncFile | AsyncSlicedFile | None,
         path: str | None = None,
+        *,
+        offset: int | None = None,
+        count: int | None = None,
     ) -> None:
         self.status = status
         self.headers = headers
@@ -35,6 +38,12 @@ class Response:  # noqa: B903
         # full-file (non-sliced) response so the ASGI server can offload the
         # file transmission via the `http.response.pathsend` extension.
         self.path = path
+        # Byte offset / count for the `http.response.zerocopysend` extension.
+        # When `offset` is set, `file` is a real (fd-backed) file object that the
+        # ASGI server transmits via `os.sendfile` and the application must close
+        # once the send completes.
+        self.offset = offset
+        self.count = count
 
 
 NOT_ALLOWED_RESPONSE = Response(
@@ -156,6 +165,7 @@ class StaticFile:
         request_headers: Mapping[str, str],
         *,
         pathsend: bool = False,
+        zerocopysend: bool = False,
     ) -> Response:
         """Variant of `get_response` that works with async HTTP requests.
         To minimize code duplication, `request_headers` conforms to WSGI header spec.
@@ -164,6 +174,12 @@ class StaticFile:
         server advertises the `http.response.pathsend` extension. In that case we
         skip opening an async file handle for a full-file send and instead populate
         `Response.path`, allowing the server to transmit the file by path.
+
+        When `zerocopysend` is True, the caller has confirmed that the ASGI server
+        advertises `http.response.zerocopysend`. This is the preferred offload path
+        because, unlike `pathsend`, it supports slicing: a real (fd-backed) file
+        handle is always opened and populated with the appropriate `offset`/`count`
+        so the server can transmit the file (or a byte range) via `os.sendfile`.
         """
         if method not in {"GET", "HEAD"}:
             return NOT_ALLOWED_RESPONSE
@@ -172,31 +188,60 @@ class StaticFile:
         path, headers = self.get_path_and_headers(request_headers)
         range_header = request_headers.get("HTTP_RANGE")
         if range_header:
-            # If we can't interpret the Range request for any reason then
-            # just ignore it and return the standard response (this
-            # behaviour is allowed by the spec). Range requests always require a
-            # real file handle since pathsend does not support slicing.
-            range_file = AsyncFile(path, "rb") if method != "HEAD" else None
-            with contextlib.suppress(ValueError):
-                return await self.aget_range_response(range_header, headers, range_file)
-            # The Range header was uninterpretable; fall through to a full send.
-            if pathsend and method != "HEAD":
+            # Range requests always require a real file handle. zerocopysend is the
+            # only offload extension that supports slicing, so when it is advertised
+            # we keep the raw (fd-backed) handle and annotate the response with the
+            # slice offset/count for the server to transmit via os.sendfile.
+            file_handle = self._open_for_send(path, method, zerocopysend)
+            try:
+                return await self.aget_range_response(range_header, headers, file_handle, zerocopysend=zerocopysend)
+            except ValueError:
+                # The Range header was uninterpretable; fall through to a full send.
+                pass
+            if method == "HEAD":
+                return Response(HTTPStatus.OK, headers, None)
+            if zerocopysend:
+                return Response(HTTPStatus.OK, headers, file_handle, offset=0)
+            if pathsend:
                 # The server will transmit the whole file by path, so discard the
-                # handle we created for range handling. (range_file is always
-                # non-None here since method != HEAD creates it above.)
-                await cast("AsyncFile", range_file).close()
+                # (always non-None for GET) handle we opened for range handling.
+                await cast("AsyncFile", file_handle).close()
                 return Response(HTTPStatus.OK, headers, None, path=path)
             # Otherwise keep the (open) handle so we can stream the full file.
-            return Response(HTTPStatus.OK, headers, range_file, path=path if method != "HEAD" else None)
+            return Response(HTTPStatus.OK, headers, file_handle, path=path)
         if method == "HEAD":
             return Response(HTTPStatus.OK, headers, None)
+        if zerocopysend:
+            # zerocopysend is the preferred offload: it handles both full-file and
+            # sliced sends. Open a real (fd-backed) handle and let the server
+            # transmit the whole file via os.sendfile (offset=0, count omitted = EOF).
+            return Response(HTTPStatus.OK, headers, self._open_for_send(path, method, zerocopysend), offset=0)
         if pathsend:
             # The server will stream the file by path, so we open no file handle
             # (and create no async file thread pool) on our side.
             return Response(HTTPStatus.OK, headers, None, path=path)
         # We do not await this async file handle to allow us the option of opening
         # it in a thread later.
-        return Response(HTTPStatus.OK, headers, AsyncFile(path, "rb"), path=path)
+        return Response(HTTPStatus.OK, headers, self._open_for_send(path, method, zerocopysend), path=path)
+
+    @staticmethod
+    def _open_for_send(
+        path: str,
+        method: str,
+        zerocopysend: bool,
+    ) -> BufferedIOBase | AsyncFile | None:
+        """Open a file handle for the given method.
+
+        For HEAD requests no body is sent, so no handle is opened. For zerocopysend
+        we open a plain synchronous file object because the ASGI server needs its
+        underlying OS file descriptor to perform the zero-copy sendfile; there is no
+        benefit to async file IO since we never read through it in Python.
+        """
+        if method == "HEAD":
+            return None
+        if zerocopysend:
+            return open(path, "rb")
+        return AsyncFile(path, "rb")
 
     def get_range_response(
         self,
@@ -230,7 +275,9 @@ class StaticFile:
         self,
         range_header: str,
         base_headers: list[tuple[str, str | None]],
-        file_handle: AsyncFile | None,
+        file_handle: BufferedIOBase | AsyncFile | None,
+        *,
+        zerocopysend: bool = False,
     ) -> Response:
         """Variant of `get_range_response` that works with async file objects."""
         headers: list[tuple[str, str | None]] = []
@@ -247,9 +294,24 @@ class StaticFile:
         start, end = self.get_byte_range(range_header, size)
         if start > end:
             return await self.aget_range_not_satisfiable_response(file_handle, size, headers)
-        sliced_file: AsyncSlicedFile | None = None
-        if file_handle is not None:
-            sliced_file = AsyncSlicedFile(file_handle, start, end)
+        if zerocopysend and file_handle is not None:
+            # Keep the raw (fd-backed) handle and let the server transmit the
+            # slice via sendfile using the byte range as offset/count.
+            headers.extend((
+                ("Content-Range", f"bytes {start}-{end}/{size}"),
+                ("Content-Length", str(end - start + 1)),
+            ))
+            return Response(
+                HTTPStatus.PARTIAL_CONTENT,
+                headers,
+                file_handle,
+                offset=start,
+                count=end - start + 1,
+            )
+        # Non-zerocopysend range sends always use an AsyncFile handle (opened via
+        # `_open_for_send` with zerocopysend=False), so wrap it in an
+        # AsyncSlicedFile to stream the requested byte range.
+        sliced_file = AsyncSlicedFile(cast("AsyncFile", file_handle), start, end) if file_handle is not None else None
         headers.extend((
             ("Content-Range", f"bytes {start}-{end}/{size}"),
             ("Content-Length", str(end - start + 1)),
@@ -299,13 +361,17 @@ class StaticFile:
 
     @staticmethod
     async def aget_range_not_satisfiable_response(
-        file_handle: AsyncFile | None,
+        file_handle: BufferedIOBase | AsyncFile | None,
         size: int,
         headers: list[tuple[str, str | None]] | None = None,
     ) -> Response:
         """Variant of `get_range_not_satisfiable_response` that works with
         async file objects. Async file handles do not need to be closed, since they
-        are only opened via context managers while being dispatched."""
+        are only opened via context managers while being dispatched. A synchronous
+        (zerocopysend) handle that was opened for a range request is closed here
+        because the unsatisfiable response discards it."""
+        if file_handle is not None and not isinstance(file_handle, AsyncFile):
+            file_handle.close()
         response_headers = list(headers) if headers else []
         response_headers.append(("Content-Range", f"bytes */{size}"))
         return Response(
@@ -430,6 +496,7 @@ class Redirect:
         request_headers: Mapping[str, str],
         *,
         pathsend: bool = False,
+        zerocopysend: bool = False,
     ) -> Response:
         return self.get_response(method, request_headers)
 

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -243,6 +243,171 @@ def test_pathsend_head_has_no_body(application, test_files):
     assert send[1]["type"] == "http.response.body"
 
 
+def test_zerocopysend_uses_zerocopysend_event(application, test_files):
+    """When the server advertises zerocopysend, a full-file GET is sent via
+    `http.response.zerocopysend` with an fd-backed file object and offset=0."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js", "extensions": {"http.response.zerocopysend": {}}})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    event = send.zerocopysend
+    assert event is not None
+    # The event carries a real fd-backed file object.
+    assert hasattr(event["file"], "fileno")
+    assert event["offset"] == 0
+    assert "count" not in event
+    assert len(send.message) == 2
+    # Per spec the application must close the descriptor after the send.
+    assert event["file"].closed
+
+
+def test_zerocopysend_full_file_content(application, test_files):
+    """The fd-backed file passed to zerocopysend holds the full file content."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/large-file.txt", "extensions": {"http.response.zerocopysend": {}}})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    event = send.zerocopysend
+    assert event is not None
+    assert event["offset"] == 0
+    assert "count" not in event
+
+
+def test_zerocopysend_range_uses_offset_and_count(application, test_files):
+    """zerocopysend supports slicing, so a Range request is offloaded with the
+    byte range as offset/count rather than streamed by us."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=0-13")],
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 206
+    assert send.headers[b"content-range"] == b"bytes 0-13/%d" % len(test_files.js_content)
+    event = send.zerocopysend
+    assert event is not None
+    assert event["offset"] == 0
+    assert event["count"] == 14
+    assert event["file"].closed
+
+
+def test_zerocopysend_suffix_range_uses_offset_and_count(application, test_files):
+    """A suffix Range request computes the correct absolute offset/count for
+    the zero-copy send."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=-4")],
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 206
+    size = len(test_files.js_content)
+    event = send.zerocopysend
+    assert event is not None
+    assert event["offset"] == size - 4
+    assert event["count"] == 4
+
+
+def test_zerocopysend_malformed_range_falls_back_to_full_send(application, test_files):
+    """An uninterpretable Range header is ignored (per spec), so the full file is
+    sent via zerocopysend (offset=0, count omitted)."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=abc")],
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    event = send.zerocopysend
+    assert event is not None
+    assert event["offset"] == 0
+    assert "count" not in event
+
+
+def test_zerocopysend_not_used_when_not_advertised(application, test_files):
+    """Without the zerocopysend extension in scope, ServeStatic streams the body
+    via `http.response.body` as usual."""
+    scope = AsgiHttpScopeEmulator({"path": "/static/app.js"})
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.body == test_files.js_content
+    assert all(msg["type"] != "http.response.zerocopysend" for msg in send.message)
+
+
+def test_zerocopysend_head_has_no_body(application, test_files):
+    """HEAD requests must not emit a zerocopysend body message."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "method": "HEAD",
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send.body == b""
+    assert send.zerocopysend is None
+    assert len(send.message) == 2
+    assert send[1]["type"] == "http.response.body"
+
+
+def test_zerocopysend_head_malformed_range_falls_back_to_headers(application, test_files):
+    """A malformed Range header on a HEAD request is ignored; because HEAD has no
+    body it must not emit a zerocopysend message, just the response headers."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "method": "HEAD",
+        "headers": [(b"range", b"bytes=abc")],
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 200
+    assert send.body == b""
+    assert send.zerocopysend is None
+    assert len(send.message) == 2
+    assert send[1]["type"] == "http.response.body"
+
+
+def test_zerocopysend_out_of_range_returns_416(application, test_files):
+    """An unsatisfiable range request returns 416 and does not emit a
+    zerocopysend event."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "headers": [(b"range", b"bytes=10000-11000")],
+        "extensions": {"http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.status == 416
+    assert send.headers[b"content-range"] == b"bytes */%d" % len(test_files.js_content)
+    assert send.zerocopysend is None
+
+
+def test_zerocopysend_preferred_over_pathsend(application, test_files):
+    """When a server advertises both extensions, zerocopysend (which supports
+    slicing) is preferred over pathsend for full-file sends."""
+    scope = AsgiHttpScopeEmulator({
+        "path": "/static/app.js",
+        "extensions": {"http.response.pathsend": {}, "http.response.zerocopysend": {}},
+    })
+    receive = AsgiReceiveEmulator()
+    send = AsgiSendEmulator()
+    asyncio.run(application(scope, receive, send))
+    assert send.zerocopysend is not None
+    assert all(msg["type"] != "http.response.pathsend" for msg in send.message)
+
+
 def test_async_file_del_does_not_join_current_thread(test_files, capsys):
     file_path = str(Path(test_files.directory) / test_files.js_path)
     holder = {"async_file": servestatic_utils.AsyncFile(file_path, "rb")}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -225,6 +225,11 @@ class AsgiSendEmulator:
         return sum(bool(msg.get("body")) for msg in self.message)
 
     @property
+    def zerocopysend(self):
+        """Return the first `http.response.zerocopysend` event, if any."""
+        return next((msg for msg in self.message if msg.get("type") == "http.response.zerocopysend"), None)
+
+    @property
     def headers(self):
         """Return the headers from the first event."""
         return dict(self[0]["headers"])


### PR DESCRIPTION
## Description

Add support for the ASGI [`http.response.zerocopysend`](https://asgi.readthedocs.io/en/latest/extensions.html#zero-copy-send) extension (e.g. [`nonecorn`](https://github.com/nonebot/nonecorn) or [`anycorn`](https://github.com/davidbrochart/anycorn)).

When the ASGI server advertises this extension, ServeStatic now offloads file transmission to the server using it rather than streaming the file through Python file IO.

Unlike the `http.response.pathsend` extension (added in #121 / Closes #119), `zerocopysend` supports slicing, so **both** full-file **and** Range (sliced) requests are transmitted zero-copy. Per the ASGI spec, the application closes the file descriptor after the send completes.

This generalizes the existing pathsend offload machinery so both extensions are handled by a single code path.

Key changes:
- `Response` now carries optional `offset`/`count` for the byte range the server should transmit (used by `zerocopysend`).
- `StaticFile.aget_response()` accepts both `pathsend` and `zerocopysend` flags. When `zerocopysend` is advertised it is preferred because it also handles sliced sends; `pathsend` remains a full-file-only fallback.
- `FileServerASGI` checks the scope's advertised `extensions` and dispatches a `http.response.zerocopysend` event with the fd-backed file object, `offset`, and (for range requests) `count`, closing the descriptor afterward.
- Added tests covering: zerocopysend dispatch for full-file and range/suffix-range sends, HEAD having no body, no dispatch when not advertised, malformed-range fallback, out-of-range 416, and zerocopysend being preferred over pathsend.

## Checklist

Please update this checklist as you complete each item:

- [x] Tests have been developed for bug fixes or new functionality.
- [x] The changelog has been updated, if necessary.
- [ ] Documentation has been updated, if necessary.
- [x] GitHub Issues closed by this PR have been linked.

Closes #120